### PR TITLE
[MAIRU-007 / #7] Claude API クライアントと分類 DTO 追加

### DIFF
--- a/app.go
+++ b/app.go
@@ -11,16 +11,21 @@ import (
 	"time"
 
 	"mairu/internal/auth"
+	"mairu/internal/claude"
 	"mairu/internal/db"
 	"mairu/internal/gmail"
 	"mairu/internal/types"
 )
 
-const gmailConnectionTimeout = 15 * time.Second
+const (
+	gmailConnectionTimeout      = 15 * time.Second
+	claudeClassificationTimeout = 45 * time.Second
+)
 
 type App struct {
 	ctx           context.Context
 	authClient    *auth.Client
+	claudeClient  *claude.Client
 	gmailClient   *gmail.Client
 	secretManager *auth.SecretManager
 	dbStore       *db.Store
@@ -39,12 +44,16 @@ type App struct {
 func NewApp() *App {
 	clientID := strings.TrimSpace(os.Getenv("MAIRU_GOOGLE_OAUTH_CLIENT_ID"))
 	clientSecret := strings.TrimSpace(os.Getenv("MAIRU_GOOGLE_OAUTH_CLIENT_SECRET"))
+	claudeModel := strings.TrimSpace(os.Getenv("MAIRU_CLAUDE_MODEL"))
 	secretManager := auth.NewSecretManager(auth.NewSystemSecretStore())
 
 	app := &App{
 		authClient: auth.NewClient(auth.Config{
 			ClientID:     clientID,
 			ClientSecret: clientSecret,
+		}),
+		claudeClient: claude.NewClient(claude.Options{
+			DefaultModel: claudeModel,
 		}),
 		gmailClient:   gmail.NewClient(gmail.Options{}),
 		secretManager: secretManager,
@@ -296,6 +305,24 @@ func (a *App) CheckGmailConnection() types.GmailConnectionResult {
 		HistoryID:      profile.HistoryID,
 		TokenRefreshed: refreshed,
 	}
+}
+
+// ClassifyEmails は保存済み Claude API キーでメール分類を実行する。
+func (a *App) ClassifyEmails(request types.ClassificationRequest) (types.ClassificationResponse, error) {
+	baseContext, cancel := context.WithTimeout(a.baseContext(), claudeClassificationTimeout)
+	defer cancel()
+
+	apiKey, err := a.secretManager.LoadClaudeAPIKey(baseContext)
+	if err != nil {
+		return types.ClassificationResponse{}, fmt.Errorf("保存済み Claude API キーを読み出せませんでした: %w", err)
+	}
+
+	client := a.claudeClient
+	if client == nil {
+		client = claude.NewClient(claude.Options{})
+	}
+
+	return client.Classify(baseContext, apiKey, request)
 }
 
 // CancelGoogleLogin は進行中の Google ログインを中断する。

--- a/app_test.go
+++ b/app_test.go
@@ -9,7 +9,9 @@ import (
 	"time"
 
 	"mairu/internal/auth"
+	"mairu/internal/claude"
 	"mairu/internal/gmail"
+	"mairu/internal/types"
 )
 
 func TestGetRuntimeStatusIncludesStoredSecretPreviews(t *testing.T) {
@@ -173,6 +175,76 @@ func TestGetRuntimeStatusClearsGmailSuccessWhenUnauthorized(t *testing.T) {
 	}
 	if status.GmailAccountEmail != "" {
 		t.Fatalf("GmailAccountEmail = %q, want empty", status.GmailAccountEmail)
+	}
+}
+
+func TestClassifyEmailsUsesStoredClaudeAPIKey(t *testing.T) {
+	t.Parallel()
+
+	store := auth.NewMemorySecretStore()
+	manager := auth.NewSecretManager(store)
+	if err := manager.SaveClaudeAPIKey(context.Background(), "claude-secret"); err != nil {
+		t.Fatalf("SaveClaudeAPIKey returned error: %v", err)
+	}
+
+	httpClient := &http.Client{
+		Transport: appRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if r.URL.String() != "https://claude.test/v1/messages" {
+				t.Fatalf("unexpected URL: %s", r.URL.String())
+			}
+			if got := r.Header.Get("x-api-key"); got != "claude-secret" {
+				t.Fatalf("x-api-key mismatch: got %q", got)
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				Body: io.NopCloser(strings.NewReader(`{
+					"content":[
+						{
+							"type":"text",
+							"text":"[{\"id\":\"msg-1\",\"category\":\"important\",\"confidence\":0.92,\"reason\":\"返信が必要です\"}]"
+						}
+					]
+				}`)),
+			}, nil
+		}),
+	}
+
+	app := &App{
+		claudeClient: claude.NewClient(claude.Options{
+			BaseURL:      "https://claude.test",
+			DefaultModel: "claude-test-model",
+			HTTPClient:   httpClient,
+		}),
+		secretManager: manager,
+	}
+
+	result, err := app.ClassifyEmails(types.ClassificationRequest{
+		Messages: []types.EmailSummary{
+			{
+				ID:      "msg-1",
+				From:    "boss@example.com",
+				Subject: "至急",
+				Snippet: "確認してください",
+				Unread:  true,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ClassifyEmails returned error: %v", err)
+	}
+
+	if result.Model != "claude-test-model" {
+		t.Fatalf("Model = %q, want %q", result.Model, "claude-test-model")
+	}
+	if len(result.Results) != 1 {
+		t.Fatalf("Results length = %d, want 1", len(result.Results))
+	}
+	if result.Results[0].ReviewLevel != types.ClassificationReviewLevelAutoApply {
+		t.Fatalf("ReviewLevel = %q, want %q", result.Results[0].ReviewLevel, types.ClassificationReviewLevelAutoApply)
 	}
 }
 

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -29,7 +29,7 @@
 | MAIRU-004 | #4 | done | Phase 1 | Google OAuth PKCE ログイン実装 | MAIRU-001, MAIRU-003 |
 | MAIRU-005 | #5 | done | Phase 1 | キーチェーン連携と機密情報保護 | MAIRU-004 |
 | MAIRU-006 | #6 | done | Phase 1 | Gmail API クライアント初期化と接続確認 | MAIRU-004, MAIRU-005 |
-| MAIRU-007 | #7 | blocked | Phase 2 | Claude API クライアントと分類 DTO | MAIRU-002, MAIRU-005 |
+| MAIRU-007 | #7 | in progress | Phase 2 | Claude API クライアントと分類 DTO | MAIRU-002, MAIRU-005 |
 | MAIRU-008 | #8 | blocked | Phase 2 | 分類確認画面と信頼度分岐 UI | MAIRU-003, MAIRU-007 |
 | MAIRU-009 | #9 | blocked | Phase 2 | Gmail アクション実行とラベル管理 | MAIRU-006, MAIRU-008 |
 | MAIRU-010 | #10 | done | Phase 3 | SQLite 初期化、スキーマ、マイグレーション | MAIRU-002 |
@@ -126,7 +126,7 @@
   - Phase 1 の完了判定に使える接続確認が実装される
 
 ### MAIRU-007: Claude API クライアントと分類 DTO
-- 状態: `blocked`
+- 状態: `in progress`
 - フェーズ: Phase 2
 - 依存: `MAIRU-002`, `MAIRU-005`
 - 目的: メール分類ロジックの核となる Claude 連携とデータ構造を先に整える。

--- a/frontend/src/lib/runtime.ts
+++ b/frontend/src/lib/runtime.ts
@@ -29,6 +29,46 @@ export type SecretOperationResult = {
     message: string;
 };
 
+export type EmailSummary = {
+    id: string;
+    threadID: string;
+    from: string;
+    subject: string;
+    snippet: string;
+    unread: boolean;
+};
+
+export type ClassificationCategory =
+    | 'important'
+    | 'newsletter'
+    | 'junk'
+    | 'archive'
+    | 'unread_priority';
+
+export type ClassificationReviewLevel =
+    | 'auto_apply'
+    | 'review'
+    | 'review_with_reason'
+    | 'hold';
+
+export type ClassificationRequest = {
+    model?: string;
+    messages: EmailSummary[];
+};
+
+export type ClassificationResult = {
+    messageID: string;
+    category: ClassificationCategory;
+    confidence: number;
+    reason: string;
+    reviewLevel: ClassificationReviewLevel;
+};
+
+export type ClassificationResponse = {
+    model: string;
+    results: ClassificationResult[];
+};
+
 export type GmailConnectionResult = {
     success: boolean;
     message: string;
@@ -109,6 +149,37 @@ type WailsAppApi = {
         | {
               Success: boolean;
               Message: string;
+          };
+    ClassifyEmails?: (request: {
+        Model?: string;
+        Messages: Array<{
+            ID: string;
+            ThreadID?: string;
+            From: string;
+            Subject: string;
+            Snippet: string;
+            Unread: boolean;
+        }>;
+    }) =>
+        | Promise<{
+              Model?: string;
+              Results?: Array<{
+                  MessageID: string;
+                  Category: ClassificationCategory;
+                  Confidence: number;
+                  Reason: string;
+                  ReviewLevel: ClassificationReviewLevel;
+              }>;
+          }>
+        | {
+              Model?: string;
+              Results?: Array<{
+                  MessageID: string;
+                  Category: ClassificationCategory;
+                  Confidence: number;
+                  Reason: string;
+                  ReviewLevel: ClassificationReviewLevel;
+              }>;
           };
     CheckGmailConnection?: () =>
         | Promise<{
@@ -254,6 +325,37 @@ export async function clearClaudeAPIKey(): Promise<SecretOperationResult> {
     return {
         success: raw.Success,
         message: raw.Message,
+    };
+}
+
+export async function classifyEmails(request: ClassificationRequest): Promise<ClassificationResponse> {
+    const appApi = window.go?.main?.App;
+    const result = appApi?.ClassifyEmails?.({
+        Model: request.model,
+        Messages: request.messages.map((message) => ({
+            ID: message.id,
+            ThreadID: message.threadID,
+            From: message.from,
+            Subject: message.subject,
+            Snippet: message.snippet,
+            Unread: message.unread,
+        })),
+    });
+
+    if (!result) {
+        throw new Error('メール分類 API がまだ公開されていません。');
+    }
+
+    const raw = await result;
+    return {
+        model: raw.Model ?? request.model ?? '',
+        results: (raw.Results ?? []).map((item) => ({
+            messageID: item.MessageID,
+            category: item.Category,
+            confidence: item.Confidence,
+            reason: item.Reason,
+            reviewLevel: item.ReviewLevel,
+        })),
     };
 }
 

--- a/internal/claude/classify.go
+++ b/internal/claude/classify.go
@@ -1,0 +1,332 @@
+package claude
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"mairu/internal/types"
+)
+
+const classificationSystemPrompt = "あなたは Gmail 整理アシスタントです。必ず JSON だけを返し、説明文や Markdown を混ぜないでください。"
+
+type apiMessageRequest struct {
+	Model       string       `json:"model"`
+	MaxTokens   int          `json:"max_tokens"`
+	Temperature float64      `json:"temperature"`
+	System      string       `json:"system"`
+	Messages    []apiMessage `json:"messages"`
+}
+
+type apiMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type apiResponse struct {
+	Content []apiContentBlock `json:"content"`
+	Error   apiErrorPayload   `json:"error"`
+}
+
+type apiContentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type apiErrorPayload struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
+type promptMessage struct {
+	ID      string `json:"id"`
+	From    string `json:"from"`
+	Subject string `json:"subject"`
+	Snippet string `json:"snippet"`
+	Unread  bool   `json:"unread"`
+}
+
+type classificationResultPayload struct {
+	ID         string  `json:"id"`
+	Category   string  `json:"category"`
+	Confidence float64 `json:"confidence"`
+	Reason     string  `json:"reason"`
+}
+
+type classificationEnvelope struct {
+	Results []classificationResultPayload `json:"results"`
+}
+
+// Classify は Claude Messages API を使ってメール一覧を分類する。
+func (c *Client) Classify(ctx context.Context, apiKey string, request types.ClassificationRequest) (types.ClassificationResponse, error) {
+	trimmedAPIKey := strings.TrimSpace(apiKey)
+	if trimmedAPIKey == "" {
+		return types.ClassificationResponse{}, fmt.Errorf("Claude API 呼び出しに必要な API キーがありません")
+	}
+
+	messages, err := validateMessages(request.Messages, c.maxBatchSize)
+	if err != nil {
+		return types.ClassificationResponse{}, err
+	}
+
+	model := strings.TrimSpace(request.Model)
+	if model == "" {
+		model = c.defaultModel
+	}
+
+	body := apiMessageRequest{
+		Model:       model,
+		MaxTokens:   c.maxTokens,
+		Temperature: 0,
+		System:      classificationSystemPrompt,
+		Messages: []apiMessage{
+			{
+				Role:    "user",
+				Content: buildClassificationPrompt(messages),
+			},
+		},
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return types.ClassificationResponse{}, fmt.Errorf("Claude API リクエストの組み立てに失敗しました: %w", err)
+	}
+
+	httpRequest, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		c.baseURL+messagesPath,
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		return types.ClassificationResponse{}, fmt.Errorf("Claude API リクエストの作成に失敗しました: %w", err)
+	}
+	httpRequest.Header.Set("Content-Type", "application/json")
+	httpRequest.Header.Set("x-api-key", trimmedAPIKey)
+	httpRequest.Header.Set("anthropic-version", c.apiVersion)
+
+	response, err := c.httpClient.Do(httpRequest)
+	if err != nil {
+		return types.ClassificationResponse{}, fmt.Errorf("Claude API へ接続できませんでした: %w", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return types.ClassificationResponse{}, decodeAPIError(response)
+	}
+
+	text, err := extractResponseText(response.Body)
+	if err != nil {
+		return types.ClassificationResponse{}, err
+	}
+
+	results, err := parseClassificationResults(text, messages)
+	if err != nil {
+		return types.ClassificationResponse{}, err
+	}
+
+	return types.ClassificationResponse{
+		Model:   model,
+		Results: results,
+	}, nil
+}
+
+func validateMessages(messages []types.EmailSummary, maxBatchSize int) ([]types.EmailSummary, error) {
+	if len(messages) == 0 {
+		return nil, fmt.Errorf("Claude 分類対象のメールがありません")
+	}
+	if len(messages) > maxBatchSize {
+		return nil, fmt.Errorf("Claude 分類は最大 %d 件までです", maxBatchSize)
+	}
+
+	normalized := make([]types.EmailSummary, 0, len(messages))
+	seenIDs := make(map[string]struct{}, len(messages))
+	for index, message := range messages {
+		id := strings.TrimSpace(message.ID)
+		if id == "" {
+			return nil, fmt.Errorf("messages[%d].ID を入力してください", index)
+		}
+		if _, exists := seenIDs[id]; exists {
+			return nil, fmt.Errorf("messages[%d].ID %q が重複しています", index, id)
+		}
+		seenIDs[id] = struct{}{}
+
+		normalized = append(normalized, types.EmailSummary{
+			ID:       id,
+			ThreadID: strings.TrimSpace(message.ThreadID),
+			From:     strings.TrimSpace(message.From),
+			Subject:  strings.TrimSpace(message.Subject),
+			Snippet:  strings.TrimSpace(message.Snippet),
+			Unread:   message.Unread,
+		})
+	}
+
+	return normalized, nil
+}
+
+func buildClassificationPrompt(messages []types.EmailSummary) string {
+	payload := make([]promptMessage, 0, len(messages))
+	for _, message := range messages {
+		payload = append(payload, promptMessage{
+			ID:      message.ID,
+			From:    message.From,
+			Subject: message.Subject,
+			Snippet: message.Snippet,
+			Unread:  message.Unread,
+		})
+	}
+
+	serialized, err := json.Marshal(payload)
+	if err != nil {
+		return "[]"
+	}
+
+	return strings.Join([]string{
+		"次のメールを 1 通ずつ分類してください。",
+		"使用できる category は important, newsletter, junk, archive, unread_priority のみです。",
+		"confidence は 0 以上 1 以下の小数、reason は日本語の短い説明にしてください。",
+		"必ず JSON 配列のみを返し、各要素に id, category, confidence, reason を含めてください。",
+		"メール情報: " + string(serialized),
+	}, "\n")
+}
+
+func decodeAPIError(response *http.Response) error {
+	var failure apiResponse
+	if err := json.NewDecoder(response.Body).Decode(&failure); err == nil {
+		message := strings.TrimSpace(failure.Error.Message)
+		if message != "" {
+			return fmt.Errorf("Claude API 分類に失敗しました (%d): %s", response.StatusCode, message)
+		}
+	}
+
+	return fmt.Errorf("Claude API 分類に失敗しました (HTTP %d)", response.StatusCode)
+}
+
+func extractResponseText(body io.Reader) (string, error) {
+	var payload apiResponse
+	if err := json.NewDecoder(body).Decode(&payload); err != nil {
+		return "", fmt.Errorf("Claude API 応答の読み取りに失敗しました: %w", err)
+	}
+
+	var builder strings.Builder
+	for _, block := range payload.Content {
+		if block.Type != "text" {
+			continue
+		}
+		text := strings.TrimSpace(block.Text)
+		if text == "" {
+			continue
+		}
+		if builder.Len() > 0 {
+			builder.WriteByte('\n')
+		}
+		builder.WriteString(text)
+	}
+
+	if builder.Len() == 0 {
+		return "", fmt.Errorf("Claude API 応答に分類結果テキストが含まれていません")
+	}
+
+	return trimCodeFence(builder.String()), nil
+}
+
+func trimCodeFence(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if !strings.HasPrefix(trimmed, "```") {
+		return trimmed
+	}
+
+	trimmed = strings.TrimPrefix(trimmed, "```")
+	trimmed = strings.TrimSpace(trimmed)
+	if strings.HasPrefix(trimmed, "json") {
+		trimmed = strings.TrimSpace(strings.TrimPrefix(trimmed, "json"))
+	}
+
+	if index := strings.LastIndex(trimmed, "```"); index >= 0 {
+		trimmed = strings.TrimSpace(trimmed[:index])
+	}
+
+	return trimmed
+}
+
+func parseClassificationResults(raw string, messages []types.EmailSummary) ([]types.ClassificationResult, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, fmt.Errorf("Claude API 応答が空です")
+	}
+
+	var direct []classificationResultPayload
+	if err := json.Unmarshal([]byte(trimmed), &direct); err == nil {
+		return normalizeResults(direct, messages)
+	}
+
+	var wrapped classificationEnvelope
+	if err := json.Unmarshal([]byte(trimmed), &wrapped); err == nil {
+		return normalizeResults(wrapped.Results, messages)
+	}
+
+	return nil, fmt.Errorf("Claude API 応答を分類結果 JSON として解釈できません")
+}
+
+func normalizeResults(entries []classificationResultPayload, messages []types.EmailSummary) ([]types.ClassificationResult, error) {
+	if len(entries) != len(messages) {
+		return nil, fmt.Errorf("Claude API 応答件数が一致しません: got %d, want %d", len(entries), len(messages))
+	}
+
+	order := make([]string, 0, len(messages))
+	expected := make(map[string]struct{}, len(messages))
+	for _, message := range messages {
+		order = append(order, message.ID)
+		expected[message.ID] = struct{}{}
+	}
+
+	normalized := make(map[string]types.ClassificationResult, len(entries))
+	for index, entry := range entries {
+		id := strings.TrimSpace(entry.ID)
+		if id == "" {
+			return nil, fmt.Errorf("Claude API 応答 results[%d].id が空です", index)
+		}
+		if _, ok := expected[id]; !ok {
+			return nil, fmt.Errorf("Claude API 応答に想定外の id %q が含まれています", id)
+		}
+		if _, exists := normalized[id]; exists {
+			return nil, fmt.Errorf("Claude API 応答に id %q が重複しています", id)
+		}
+
+		category := types.ClassificationCategory(strings.TrimSpace(entry.Category))
+		if !category.IsValid() {
+			return nil, fmt.Errorf("Claude API 応答 results[%d].category %q は未対応です", index, entry.Category)
+		}
+		if entry.Confidence < 0 || entry.Confidence > 1 {
+			return nil, fmt.Errorf("Claude API 応答 results[%d].confidence は 0〜1 の範囲で指定してください", index)
+		}
+
+		reason := strings.TrimSpace(entry.Reason)
+		if reason == "" {
+			return nil, fmt.Errorf("Claude API 応答 results[%d].reason が空です", index)
+		}
+
+		normalized[id] = types.ClassificationResult{
+			MessageID:   id,
+			Category:    category,
+			Confidence:  entry.Confidence,
+			Reason:      reason,
+			ReviewLevel: types.ReviewLevelForConfidence(entry.Confidence),
+		}
+	}
+
+	results := make([]types.ClassificationResult, 0, len(order))
+	for _, id := range order {
+		result, ok := normalized[id]
+		if !ok {
+			return nil, fmt.Errorf("Claude API 応答に id %q の結果がありません", id)
+		}
+		results = append(results, result)
+	}
+
+	return results, nil
+}

--- a/internal/claude/client.go
+++ b/internal/claude/client.go
@@ -1,17 +1,78 @@
 package claude
 
-import "mairu/internal/types"
+import (
+	"net/http"
+	"strings"
 
-// Client は Claude API クライアント実装の受け口となるプレースホルダ。
-type Client struct{}
+	"mairu/internal/types"
+)
 
-// ClassifyRequest は分類対象メールとモデル指定をまとめる。
-type ClassifyRequest struct {
-	Model    string
-	Messages []types.EmailSummary
+const (
+	defaultBaseURL    = "https://api.anthropic.com"
+	defaultAPIVersion = "2023-06-01"
+	defaultModel      = "claude-sonnet-4-5-20250929"
+	defaultMaxTokens  = 2048
+	messagesPath      = "/v1/messages"
+)
+
+// Options は Claude API クライアント生成時の設定をまとめる。
+type Options struct {
+	BaseURL      string
+	APIVersion   string
+	DefaultModel string
+	MaxTokens    int
+	MaxBatchSize int
+	HTTPClient   *http.Client
 }
 
-// ClassifyResult は分類結果の受け渡しに使う。
-type ClassifyResult struct {
-	Results []types.ClassificationResult
+// Client は Claude Messages API を呼び出す最小実装。
+type Client struct {
+	baseURL      string
+	apiVersion   string
+	defaultModel string
+	maxTokens    int
+	maxBatchSize int
+	httpClient   *http.Client
+}
+
+// NewClient は Claude API クライアントを初期化する。
+func NewClient(options Options) *Client {
+	baseURL := strings.TrimSpace(options.BaseURL)
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+
+	apiVersion := strings.TrimSpace(options.APIVersion)
+	if apiVersion == "" {
+		apiVersion = defaultAPIVersion
+	}
+
+	defaultModelName := strings.TrimSpace(options.DefaultModel)
+	if defaultModelName == "" {
+		defaultModelName = defaultModel
+	}
+
+	maxTokens := options.MaxTokens
+	if maxTokens <= 0 {
+		maxTokens = defaultMaxTokens
+	}
+
+	maxBatchSize := options.MaxBatchSize
+	if maxBatchSize <= 0 {
+		maxBatchSize = types.ClassificationMaxBatchSize
+	}
+
+	httpClient := options.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	return &Client{
+		baseURL:      strings.TrimRight(baseURL, "/"),
+		apiVersion:   apiVersion,
+		defaultModel: defaultModelName,
+		maxTokens:    maxTokens,
+		maxBatchSize: maxBatchSize,
+		httpClient:   httpClient,
+	}
 }

--- a/internal/claude/client_test.go
+++ b/internal/claude/client_test.go
@@ -1,0 +1,204 @@
+package claude
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"mairu/internal/types"
+)
+
+func TestClassify(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient(Options{
+		BaseURL:      "https://claude.test",
+		DefaultModel: "claude-test-model",
+		HTTPClient: &http.Client{
+			Transport: claudeRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+				if r.Method != http.MethodPost {
+					t.Fatalf("unexpected method: got %s, want %s", r.Method, http.MethodPost)
+				}
+				if r.URL.String() != "https://claude.test/v1/messages" {
+					t.Fatalf("unexpected URL: got %s", r.URL.String())
+				}
+				if got := r.Header.Get("x-api-key"); got != "claude-secret" {
+					t.Fatalf("x-api-key mismatch: got %q", got)
+				}
+				if got := r.Header.Get("anthropic-version"); got != defaultAPIVersion {
+					t.Fatalf("anthropic-version mismatch: got %q", got)
+				}
+
+				payload, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatalf("ReadAll returned error: %v", err)
+				}
+
+				var body struct {
+					Model    string `json:"model"`
+					Messages []struct {
+						Role    string `json:"role"`
+						Content string `json:"content"`
+					} `json:"messages"`
+				}
+				if err := json.Unmarshal(payload, &body); err != nil {
+					t.Fatalf("json.Unmarshal returned error: %v", err)
+				}
+				if body.Model != "claude-test-model" {
+					t.Fatalf("model = %q, want %q", body.Model, "claude-test-model")
+				}
+				if len(body.Messages) != 1 {
+					t.Fatalf("messages length = %d, want 1", len(body.Messages))
+				}
+				if !strings.Contains(body.Messages[0].Content, `"id":"msg-1"`) {
+					t.Fatalf("prompt does not contain msg-1: %q", body.Messages[0].Content)
+				}
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+					Body: io.NopCloser(strings.NewReader(`{
+						"content":[
+							{
+								"type":"text",
+								"text":"[{\"id\":\"msg-2\",\"category\":\"newsletter\",\"confidence\":0.88,\"reason\":\"定期配信です\"},{\"id\":\"msg-1\",\"category\":\"important\",\"confidence\":0.95,\"reason\":\"顧客対応が必要です\"}]"
+							}
+						]
+					}`)),
+				}, nil
+			}),
+		},
+	})
+
+	result, err := client.Classify(context.Background(), " claude-secret ", types.ClassificationRequest{
+		Messages: []types.EmailSummary{
+			{ID: "msg-1", From: "boss@example.com", Subject: "至急確認", Snippet: "確認をお願いします", Unread: true},
+			{ID: "msg-2", From: "news@example.com", Subject: "今週のニュース", Snippet: "最新情報です", Unread: false},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Classify returned error: %v", err)
+	}
+
+	if result.Model != "claude-test-model" {
+		t.Fatalf("Model = %q, want %q", result.Model, "claude-test-model")
+	}
+	if len(result.Results) != 2 {
+		t.Fatalf("Results length = %d, want 2", len(result.Results))
+	}
+	if result.Results[0].MessageID != "msg-1" {
+		t.Fatalf("Results[0].MessageID = %q, want %q", result.Results[0].MessageID, "msg-1")
+	}
+	if result.Results[0].ReviewLevel != types.ClassificationReviewLevelAutoApply {
+		t.Fatalf("Results[0].ReviewLevel = %q, want %q", result.Results[0].ReviewLevel, types.ClassificationReviewLevelAutoApply)
+	}
+	if result.Results[1].ReviewLevel != types.ClassificationReviewLevelReview {
+		t.Fatalf("Results[1].ReviewLevel = %q, want %q", result.Results[1].ReviewLevel, types.ClassificationReviewLevelReview)
+	}
+}
+
+func TestClassifyRejectsTooManyMessages(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient(Options{MaxBatchSize: 2})
+
+	_, err := client.Classify(context.Background(), "claude-secret", types.ClassificationRequest{
+		Messages: []types.EmailSummary{
+			{ID: "msg-1"},
+			{ID: "msg-2"},
+			{ID: "msg-3"},
+		},
+	})
+	if err == nil {
+		t.Fatalf("Classify returned nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "最大 2 件") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestClassifyReturnsAPIError(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient(Options{
+		BaseURL: "https://claude.test",
+		HTTPClient: &http.Client{
+			Transport: claudeRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusTooManyRequests,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+					Body: io.NopCloser(strings.NewReader(`{
+						"error":{
+							"type":"rate_limit_error",
+							"message":"rate limit exceeded"
+						}
+					}`)),
+				}, nil
+			}),
+		},
+	})
+
+	_, err := client.Classify(context.Background(), "claude-secret", types.ClassificationRequest{
+		Messages: []types.EmailSummary{
+			{ID: "msg-1"},
+		},
+	})
+	if err == nil {
+		t.Fatalf("Classify returned nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "rate limit exceeded") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestClassifyRejectsMissingResult(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient(Options{
+		BaseURL: "https://claude.test",
+		HTTPClient: &http.Client{
+			Transport: claudeRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+					Body: io.NopCloser(strings.NewReader(`{
+						"content":[
+							{
+								"type":"text",
+								"text":"[{\"id\":\"msg-1\",\"category\":\"important\",\"confidence\":0.95,\"reason\":\"要対応\"}]"
+							}
+						]
+					}`)),
+				}, nil
+			}),
+		},
+	})
+
+	_, err := client.Classify(context.Background(), "claude-secret", types.ClassificationRequest{
+		Messages: []types.EmailSummary{
+			{ID: "msg-1"},
+			{ID: "msg-2"},
+		},
+	})
+	if err == nil {
+		t.Fatalf("Classify returned nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "応答件数が一致しません") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+type claudeRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn claudeRoundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return fn(r)
+}

--- a/internal/types/dto.go
+++ b/internal/types/dto.go
@@ -23,12 +23,70 @@ const (
 	ClassificationCategoryUnreadPriority ClassificationCategory = "unread_priority"
 )
 
+const (
+	ClassificationMaxBatchSize      = 50
+	ClassificationAutoApplyMinimum  = 0.90
+	ClassificationReviewMinimum     = 0.70
+	ClassificationReasonHintMinimum = 0.50
+)
+
+// IsValid は既知の分類カテゴリかを判定する。
+func (c ClassificationCategory) IsValid() bool {
+	switch c {
+	case ClassificationCategoryImportant,
+		ClassificationCategoryNewsletter,
+		ClassificationCategoryJunk,
+		ClassificationCategoryArchive,
+		ClassificationCategoryUnreadPriority:
+		return true
+	default:
+		return false
+	}
+}
+
+// ClassificationReviewLevel は信頼度に応じた UI 上の扱いを表す。
+type ClassificationReviewLevel string
+
+const (
+	ClassificationReviewLevelAutoApply        ClassificationReviewLevel = "auto_apply"
+	ClassificationReviewLevelReview           ClassificationReviewLevel = "review"
+	ClassificationReviewLevelReviewWithReason ClassificationReviewLevel = "review_with_reason"
+	ClassificationReviewLevelHold             ClassificationReviewLevel = "hold"
+)
+
+// ReviewLevelForConfidence は信頼度から UI の分岐を決める。
+func ReviewLevelForConfidence(confidence float64) ClassificationReviewLevel {
+	switch {
+	case confidence >= ClassificationAutoApplyMinimum:
+		return ClassificationReviewLevelAutoApply
+	case confidence >= ClassificationReviewMinimum:
+		return ClassificationReviewLevelReview
+	case confidence >= ClassificationReasonHintMinimum:
+		return ClassificationReviewLevelReviewWithReason
+	default:
+		return ClassificationReviewLevelHold
+	}
+}
+
+// ClassificationRequest は Claude 分類 API 呼び出し入力を表す。
+type ClassificationRequest struct {
+	Model    string
+	Messages []EmailSummary
+}
+
 // ClassificationResult は分類 API と UI 間で共有する結果 DTO。
 type ClassificationResult struct {
-	MessageID  string
-	Category   ClassificationCategory
-	Confidence int
-	Reason     string
+	MessageID   string
+	Category    ClassificationCategory
+	Confidence  float64
+	Reason      string
+	ReviewLevel ClassificationReviewLevel
+}
+
+// ClassificationResponse は Claude 分類 API 呼び出し結果を表す。
+type ClassificationResponse struct {
+	Model   string
+	Results []ClassificationResult
 }
 
 // ActionKind は Gmail に対する実行種別を表す。

--- a/internal/types/dto_test.go
+++ b/internal/types/dto_test.go
@@ -28,6 +28,59 @@ func TestClassificationCategoryValues(t *testing.T) {
 	}
 }
 
+func TestClassificationCategoryIsValid(t *testing.T) {
+	t.Parallel()
+
+	if !ClassificationCategoryImportant.IsValid() {
+		t.Fatalf("ClassificationCategoryImportant.IsValid() = false, want true")
+	}
+
+	if ClassificationCategory("unknown").IsValid() {
+		t.Fatalf("ClassificationCategory(\"unknown\").IsValid() = true, want false")
+	}
+}
+
+func TestReviewLevelForConfidence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		confidence float64
+		want       ClassificationReviewLevel
+	}{
+		{
+			name:       "auto apply",
+			confidence: 0.90,
+			want:       ClassificationReviewLevelAutoApply,
+		},
+		{
+			name:       "review",
+			confidence: 0.70,
+			want:       ClassificationReviewLevelReview,
+		},
+		{
+			name:       "review with reason",
+			confidence: 0.50,
+			want:       ClassificationReviewLevelReviewWithReason,
+		},
+		{
+			name:       "hold",
+			confidence: 0.49,
+			want:       ClassificationReviewLevelHold,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ReviewLevelForConfidence(tt.confidence); got != tt.want {
+				t.Fatalf("ReviewLevelForConfidence(%0.2f) = %q, want %q", tt.confidence, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestActionKindValues(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## 概要
- MAIRU-007 の Claude API クライアントと分類 DTO を実装
- Wails から分類 API を直接呼べるエントリポイントを追加
- TypeScript 側に分類結果受け取り用の型と runtime API を追加

## 詳細
- Claude Messages API を呼ぶ最小クライアントを追加
- 50 件バッチ検証、モデル切り替え、応答 JSON の正規化を実装
- confidence に応じた reviewLevel を DTO として定義
- App.ClassifyEmails で保存済み Claude API キーを使った分類実行を追加
- Claude API 実キーで 1 件の live classification を実行し疎通確認済み

## 実行したコマンド
- go test ./...
- npm --prefix frontend run lint
- go test -run TestLiveClaudeClassification -v .

## テスト結果
- Go テスト成功
- TypeScript 型チェック成功
- Claude API の live classification 成功

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **新機能**
  * Gmail接続確認機能を追加。接続状態、メールアドレス、メッセージ数を表示
  * Claude APIを使用してメール分類を実装。信頼度に基づいた自動適用・レビューレベルを自動判定
  * Google認証トークンとClaude APIキーの安全なプレビュー表示機能を追加
  * Settings画面にGmail接続ステータスと詳細情報を表示

* **テスト**
  * Gmail接続、トークン更新、メール分類フローの包括的なユニットテスト追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->