### PR TITLE
[MAIRU-020 / #40] 50 件バッチ checkpoint 保存と再開

### DIFF
--- a/app.go
+++ b/app.go
@@ -1448,23 +1448,28 @@ func (a *App) runScheduledClassification(ctx context.Context) (scheduler.Result,
 			return failed, maybeMarkSchedulerRetryable(err)
 		}
 
-		aggregated.Processed += pageResult.Processed
-		aggregated.Success += pageResult.Success
-		aggregated.Failed += pageResult.Failed
-		aggregated.PendingApproval += pageResult.PendingApproval
-		currentProcessedCount += pageResult.Processed
-		checkpoint.CompletedBatches++
-		checkpoint.Processed = aggregated.Processed
-		checkpoint.Success = aggregated.Success
-		checkpoint.Failed = aggregated.Failed
-		checkpoint.PendingApproval = aggregated.PendingApproval
-		checkpoint.Skipped += schedulerResultSkippedCount(pageResult)
-		checkpoint.LastStopReason = ""
-		checkpoint.LastError = ""
-		checkpoint.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
-		if err := a.saveClassificationCheckpoint(checkpoint); err != nil {
+		nextAggregated := aggregated
+		nextAggregated.Processed += pageResult.Processed
+		nextAggregated.Success += pageResult.Success
+		nextAggregated.Failed += pageResult.Failed
+		nextAggregated.PendingApproval += pageResult.PendingApproval
+		nextCurrentProcessedCount := currentProcessedCount + pageResult.Processed
+		nextCheckpoint := checkpoint
+		nextCheckpoint.CompletedBatches++
+		nextCheckpoint.Processed = nextAggregated.Processed
+		nextCheckpoint.Success = nextAggregated.Success
+		nextCheckpoint.Failed = nextAggregated.Failed
+		nextCheckpoint.PendingApproval = nextAggregated.PendingApproval
+		nextCheckpoint.Skipped += schedulerResultSkippedCount(pageResult)
+		nextCheckpoint.LastStopReason = ""
+		nextCheckpoint.LastError = ""
+		nextCheckpoint.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+		if err := a.saveClassificationCheckpoint(nextCheckpoint); err != nil {
 			return aggregated, fmt.Errorf("分類 checkpoint を保存できませんでした: %w", err)
 		}
+		aggregated = nextAggregated
+		currentProcessedCount = nextCurrentProcessedCount
+		checkpoint = nextCheckpoint
 
 		nextPageToken := strings.TrimSpace(fetched.NextPageToken)
 		if nextPageToken == "" {

--- a/app_test.go
+++ b/app_test.go
@@ -1827,6 +1827,123 @@ func TestRunScheduledClassificationStoresCheckpointOnFirstBatchFailure(t *testin
 	}
 }
 
+func TestRunScheduledClassificationDoesNotMutateAggregatedWhenCheckpointSaveFails(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store, err := db.Open(ctx, db.OpenOptions{
+		Path: filepath.Join(t.TempDir(), "mairu.db"),
+	})
+	if err != nil {
+		t.Fatalf("db.Open returned error: %v", err)
+	}
+	closed := false
+	t.Cleanup(func() {
+		if closed {
+			return
+		}
+		if err := store.Close(); err != nil {
+			t.Fatalf("store.Close returned error: %v", err)
+		}
+	})
+
+	secretStore := auth.NewMemorySecretStore()
+	secretManager := auth.NewSecretManager(secretStore)
+	if err := secretManager.SaveGoogleToken(ctx, auth.TokenSet{AccessToken: "access-token"}); err != nil {
+		t.Fatalf("SaveGoogleToken returned error: %v", err)
+	}
+	if err := secretManager.SaveClaudeAPIKey(ctx, "claude-api-key"); err != nil {
+		t.Fatalf("SaveClaudeAPIKey returned error: %v", err)
+	}
+
+	lastRunAt := time.Date(2026, time.March, 8, 9, 0, 0, 0, time.UTC)
+	if err := store.SetSetting(
+		ctx,
+		fmt.Sprintf(schedulerSettingLastRunTemplate, schedulerJobClassification),
+		lastRunAt.Format(time.RFC3339),
+	); err != nil {
+		t.Fatalf("SetSetting(job last_run_at) returned error: %v", err)
+	}
+
+	app := &App{
+		ctx:           ctx,
+		authClient:    auth.NewClient(auth.Config{}),
+		secretManager: secretManager,
+		gmailClient: gmail.NewClient(gmail.Options{
+			BaseURL: "https://gmail.test",
+			HTTPClient: &http.Client{
+				Transport: appRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+					switch r.URL.Path {
+					case "/gmail/v1/users/me/messages":
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Header: http.Header{
+								"Content-Type": []string{"application/json"},
+							},
+							Body: io.NopCloser(strings.NewReader(`{
+								"messages":[{"id":"m1","threadId":"t1"}]
+							}`)),
+						}, nil
+					case "/gmail/v1/users/me/messages/m1":
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Header: http.Header{
+								"Content-Type": []string{"application/json"},
+							},
+							Body: io.NopCloser(strings.NewReader(`{
+								"id":"m1",
+								"threadId":"t1",
+								"snippet":"one",
+								"labelIds":["INBOX","UNREAD"],
+								"payload":{"headers":[{"name":"From","value":"one@example.com"},{"name":"Subject","value":"one"}]}
+							}`)),
+						}, nil
+					default:
+						t.Fatalf("unexpected Gmail URL: %s", r.URL.String())
+						return nil, nil
+					}
+				}),
+			},
+		}),
+		claudeClient: claude.NewClient(claude.Options{
+			BaseURL: "https://claude.test",
+			HTTPClient: &http.Client{
+				Transport: appRoundTripFunc(func(*http.Request) (*http.Response, error) {
+					if err := store.Close(); err != nil {
+						t.Fatalf("store.Close returned error: %v", err)
+					}
+					closed = true
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header: http.Header{
+							"Content-Type": []string{"application/json"},
+						},
+						Body: io.NopCloser(strings.NewReader(`{
+							"content":[{"type":"text","text":"{\"results\":[{\"id\":\"m1\",\"category\":\"important\",\"confidence\":0.8,\"reason\":\"review\"}]}"}]
+						}`)),
+					}, nil
+				}),
+			},
+		}),
+		dbStore:       store,
+		databaseReady: true,
+	}
+
+	result, err := app.runScheduledClassification(ctx)
+	if err == nil {
+		t.Fatalf("runScheduledClassification error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "分類 checkpoint を保存できませんでした") {
+		t.Fatalf("error = %v, want checkpoint save error", err)
+	}
+	if result.Processed != 0 {
+		t.Fatalf("result.Processed = %d, want 0", result.Processed)
+	}
+	if result.PendingApproval != 0 {
+		t.Fatalf("result.PendingApproval = %d, want 0", result.PendingApproval)
+	}
+}
+
 func TestMaybeMarkSchedulerRetryableRecognizesParenthesizedStatus(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## 概要
- MAIRU-020 (#40) として、定期 classification の 50 件バッチ checkpoint 保存と再開を実装
- settings ベースで checkpoint を永続化し、再起動後も再開できるようにした
- 失敗時の停止理由（timeout/retry_exhausted/canceled など）を checkpoint に記録

## 詳細
- `app.go`
  - `scheduler.classification.checkpoint` を追加
  - `runScheduledClassification` で checkpoint 読込、完了済みバッチのスキップ再開、バッチ完了ごとの checkpoint 更新を実装
  - バッチ失敗時は checkpoint を進めないようにし、最後に完了したバッチ位置を維持
  - classification ジョブ成功時に checkpoint をクリア、失敗時に停止理由とエラー詳細を保存
- `app_test.go`
  - checkpoint からの再開
  - バッチ途中失敗時の checkpoint 保持
  - 成功時 checkpoint クリア
  - 失敗時停止理由保存
  のテストを追加

## 実行したコマンド
- `gofmt -w app.go app_test.go`
- `go test ./...`

## テスト結果
- `go test ./...` 成功

Closes #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * スケジュール済み分類のチェックポイントをJSONで永続化し、ページ単位の進捗から中断再開が可能に。
  * 再開時の進捗集計とサマリ生成を改善し、処理完了／中断理由が反映されるように。
  * ラベルの正規化・比較を追加して再開時の整合性を強化。
  * ジョブ成功／失敗時にチェックポイントを自動で更新・クリアするイベント処理を追加。

* **テスト**
  * チェックポイントの保存・再開・失敗保持に関する単体テストを大幅に拡充。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->