### PR TITLE
[MAIRU-023] Google Workspace CLI (gws) 統合基盤のPoC

### DIFF
--- a/app.go
+++ b/app.go
@@ -20,6 +20,7 @@ import (
 	"mairu/internal/db"
 	"mairu/internal/exporter"
 	"mairu/internal/gmail"
+	"mairu/internal/gws"
 	"mairu/internal/scheduler"
 	"mairu/internal/types"
 )
@@ -28,6 +29,7 @@ const (
 	gmailConnectionTimeout      = 15 * time.Second
 	gmailActionTimeout          = 45 * time.Second
 	claudeClassificationTimeout = 45 * time.Second
+	gwsCommandTimeout           = 20 * time.Second
 	dbOperationTimeout          = 10 * time.Second
 	blocklistSuggestionMinimum  = 3
 	defaultExportDirName        = "Downloads"
@@ -85,6 +87,7 @@ type App struct {
 	authClient    *auth.Client
 	claudeClient  *claude.Client
 	gmailClient   *gmail.Client
+	gwsClient     *gws.Client
 	secretManager *auth.SecretManager
 	dbStore       *db.Store
 
@@ -121,6 +124,7 @@ func NewApp() *App {
 			DefaultModel: claudeModel,
 		}),
 		gmailClient:   gmail.NewClient(gmail.Options{}),
+		gwsClient:     gws.NewClient(gws.Options{}),
 		secretManager: secretManager,
 		eventsEmit:    runtime.EventsEmit,
 	}
@@ -171,6 +175,8 @@ func (a *App) GetRuntimeStatus() types.RuntimeStatus {
 	googleConfigured := a.authClient.IsConfigured()
 	googleTokenPreview := ""
 	claudeKeyPreview := ""
+	gwsStatus := buildUnavailableGWSStatusMessage()
+	gwsAvailable := false
 
 	authorized, err := a.secretManager.HasGoogleToken(baseContext)
 	if err != nil {
@@ -218,6 +224,16 @@ func (a *App) GetRuntimeStatus() types.RuntimeStatus {
 		claudeStatus = buildUnstoredClaudeStatusMessage()
 	}
 
+	if a.gwsClient != nil {
+		detection := a.gwsClient.Detect()
+		gwsAvailable = detection.Available
+		if detection.Available {
+			gwsStatus = buildAvailableGWSStatusMessage(detection.BinaryPath)
+		} else if strings.TrimSpace(detection.Message) != "" {
+			gwsStatus = detection.Message
+		}
+	}
+
 	return types.RuntimeStatus{
 		Authorized:         authorized,
 		GoogleConfigured:   googleConfigured,
@@ -229,6 +245,8 @@ func (a *App) GetRuntimeStatus() types.RuntimeStatus {
 		ClaudeConfigured:   claudeConfigured,
 		ClaudeStatus:       claudeStatus,
 		ClaudeKeyPreview:   claudeKeyPreview,
+		GWSAvailable:       gwsAvailable,
+		GWSStatus:          gwsStatus,
 		DatabaseReady:      databaseReady,
 		LastRunAt:          lastRunAt,
 	}
@@ -488,6 +506,61 @@ func (a *App) CheckGmailConnection() types.GmailConnectionResult {
 		ThreadsTotal:   profile.ThreadsTotal,
 		HistoryID:      profile.HistoryID,
 		TokenRefreshed: refreshed,
+	}
+}
+
+// CheckGWSDiagnostics は gws の導入状態とバージョン取得を診断する。
+func (a *App) CheckGWSDiagnostics() types.GWSDiagnosticsResult {
+	if a.gwsClient == nil {
+		return types.GWSDiagnosticsResult{
+			Success:   false,
+			Available: false,
+			Message:   "gws クライアントが初期化されていません。",
+			ErrorKind: types.GWSCLIErrorKindExecution,
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(a.baseContext(), gwsCommandTimeout)
+	defer cancel()
+
+	result := a.gwsClient.Diagnose(ctx)
+	return types.GWSDiagnosticsResult{
+		Success:    result.Success,
+		Available:  result.Available,
+		Message:    result.Message,
+		BinaryPath: result.BinaryPath,
+		Version:    result.Version,
+		Command:    result.Command,
+		Output:     result.Output,
+		ErrorKind:  mapGWSErrorKind(result.ErrorKind),
+	}
+}
+
+// PreviewGWSGmailDryRun は gws Gmail read-only dry-run の PoC を実行する。
+func (a *App) PreviewGWSGmailDryRun(request types.GWSGmailDryRunRequest) types.GWSGmailDryRunResult {
+	if a.gwsClient == nil {
+		return types.GWSGmailDryRunResult{
+			Success:   false,
+			Message:   "gws クライアントが初期化されていません。",
+			ErrorKind: types.GWSCLIErrorKindExecution,
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(a.baseContext(), gwsCommandTimeout)
+	defer cancel()
+
+	result := a.gwsClient.RunGmailListDryRun(ctx, gws.GmailDryRunRequest{
+		Query:      request.Query,
+		MaxResults: request.MaxResults,
+	})
+
+	return types.GWSGmailDryRunResult{
+		Success:    result.Success,
+		Message:    result.Message,
+		BinaryPath: result.BinaryPath,
+		Command:    result.Command,
+		Output:     result.Output,
+		ErrorKind:  mapGWSErrorKind(result.ErrorKind),
 	}
 }
 
@@ -1103,9 +1176,38 @@ func buildUnstoredClaudeStatusMessage() string {
 	return "Claude API キーを保存すると、次の分類機能から利用できます。"
 }
 
+func buildAvailableGWSStatusMessage(binaryPath string) string {
+	trimmed := strings.TrimSpace(binaryPath)
+	if trimmed == "" {
+		return "gws を利用できます。"
+	}
+	return fmt.Sprintf("gws を利用できます (%s)", trimmed)
+}
+
+func buildUnavailableGWSStatusMessage() string {
+	return "gws は未導入です。必要な場合のみインストールしてください。"
+}
+
 func buildCredentialErrorMessage(prefix string, err error) string {
 	log.Printf("%s detail=%v", prefix, err)
 	return prefix + " 詳細はアプリのログを確認してください。"
+}
+
+func mapGWSErrorKind(kind gws.ErrorKind) types.GWSCLIErrorKind {
+	switch kind {
+	case gws.ErrorKindNone:
+		return types.GWSCLIErrorKindNone
+	case gws.ErrorKindNotInstalled:
+		return types.GWSCLIErrorKindNotInstalled
+	case gws.ErrorKindAuth:
+		return types.GWSCLIErrorKindAuth
+	case gws.ErrorKindInvalidCommand:
+		return types.GWSCLIErrorKindInvalidCommand
+	case gws.ErrorKindTimeout:
+		return types.GWSCLIErrorKindTimeout
+	default:
+		return types.GWSCLIErrorKindExecution
+	}
 }
 
 func shouldUseStoredAuthMessage(message string) bool {

--- a/app_test.go
+++ b/app_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -16,6 +17,7 @@ import (
 	"mairu/internal/claude"
 	"mairu/internal/db"
 	"mairu/internal/gmail"
+	"mairu/internal/gws"
 	"mairu/internal/scheduler"
 	"mairu/internal/types"
 )
@@ -76,6 +78,80 @@ func TestGetRuntimeStatusFallsBackToAccessTokenPreview(t *testing.T) {
 
 	if status.GoogleTokenPreview != "acce****oken" {
 		t.Fatalf("GoogleTokenPreview = %q, want %q", status.GoogleTokenPreview, "acce****oken")
+	}
+}
+
+func TestGetRuntimeStatusIncludesGWSAvailability(t *testing.T) {
+	t.Parallel()
+
+	binaryPath := writeTestExecutableScript(t, `#!/bin/sh
+echo "gws 0.9.0"
+`)
+
+	app := &App{
+		authClient:    auth.NewClient(auth.Config{ClientID: "client-id", ClientSecret: "client-secret"}),
+		secretManager: auth.NewSecretManager(auth.NewMemorySecretStore()),
+		gwsClient:     gws.NewClient(gws.Options{BinaryPath: binaryPath}),
+	}
+
+	status := app.GetRuntimeStatus()
+	if !status.GWSAvailable {
+		t.Fatalf("GWSAvailable = false, want true")
+	}
+	if !strings.Contains(status.GWSStatus, binaryPath) {
+		t.Fatalf("GWSStatus = %q, want path included", status.GWSStatus)
+	}
+}
+
+func TestCheckGWSDiagnosticsReturnsResult(t *testing.T) {
+	t.Parallel()
+
+	binaryPath := writeTestExecutableScript(t, `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "gws 0.9.0"
+  exit 0
+fi
+echo "unexpected" >&2
+exit 3
+`)
+
+	app := &App{
+		gwsClient: gws.NewClient(gws.Options{BinaryPath: binaryPath}),
+	}
+
+	result := app.CheckGWSDiagnostics()
+	if !result.Success {
+		t.Fatalf("Success = false, want true (message=%q output=%q)", result.Message, result.Output)
+	}
+	if result.ErrorKind != types.GWSCLIErrorKindNone {
+		t.Fatalf("ErrorKind = %q, want %q", result.ErrorKind, types.GWSCLIErrorKindNone)
+	}
+	if result.Version != "gws 0.9.0" {
+		t.Fatalf("Version = %q, want %q", result.Version, "gws 0.9.0")
+	}
+}
+
+func TestPreviewGWSGmailDryRunMapsInvalidCommand(t *testing.T) {
+	t.Parallel()
+
+	binaryPath := writeTestExecutableScript(t, `#!/bin/sh
+echo "invalid command" >&2
+exit 3
+`)
+
+	app := &App{
+		gwsClient: gws.NewClient(gws.Options{BinaryPath: binaryPath}),
+	}
+
+	result := app.PreviewGWSGmailDryRun(types.GWSGmailDryRunRequest{
+		Query:      "label:inbox",
+		MaxResults: 10,
+	})
+	if result.Success {
+		t.Fatalf("Success = true, want false")
+	}
+	if result.ErrorKind != types.GWSCLIErrorKindInvalidCommand {
+		t.Fatalf("ErrorKind = %q, want %q", result.ErrorKind, types.GWSCLIErrorKindInvalidCommand)
 	}
 }
 
@@ -2531,6 +2607,16 @@ func TestStartSchedulerSkipsUnimplementedJobs(t *testing.T) {
 	if !app.schedulerSvc.Trigger(schedulerJobBlocklist) {
 		t.Fatalf("Trigger(blocklist) = false, want true")
 	}
+}
+
+func writeTestExecutableScript(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "gws-test.sh")
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("os.WriteFile returned error: %v", err)
+	}
+	return path
 }
 
 type appRoundTripFunc func(*http.Request) (*http.Response, error)

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -45,7 +45,7 @@
 | MAIRU-020 | #40 | ready | Phase 4 | 50 件バッチ checkpoint 保存と再開 | MAIRU-010, MAIRU-013, MAIRU-018 |
 | MAIRU-021 | #41 | ready | Phase 4 | `action_logs` ベースの Gmail アクション重複防止 | MAIRU-009, MAIRU-010, MAIRU-018 |
 | MAIRU-022 | #42 | blocked | Phase 4 | 手動 backlog 実行の件数上限と再開導線 | MAIRU-019, MAIRU-020, MAIRU-021 |
-| MAIRU-023 | #46 | backlog | v2+ | Google Workspace CLI (`gws`) 統合基盤の PoC | MAIRU-017 |
+| MAIRU-023 | #46 | in progress | v2+ | Google Workspace CLI (`gws`) 統合基盤の PoC | MAIRU-017 |
 
 ## Issue 詳細
 
@@ -377,7 +377,7 @@
   - 段階消化の運用手順がドキュメントで説明できる
 
 ### MAIRU-023: Google Workspace CLI (`gws`) 統合基盤の PoC
-- 状態: `backlog`
+- 状態: `in progress`
 - フェーズ: v2+
 - GitHub: `#46`
 - 依存: `MAIRU-017`

--- a/docs/mairu_023_gws_poc.md
+++ b/docs/mairu_023_gws_poc.md
@@ -1,0 +1,75 @@
+# MAIRU-023: Google Workspace CLI (`gws`) 統合 PoC
+
+## 目的
+
+MAIRU の既存 Gmail API 実装 (`internal/gmail`) を置き換えずに、将来の AI アシスタント機能向け拡張経路として `gws` 連携を検証する。
+
+この PoC では以下のみを実施する。
+
+- `gws --version` の実行診断
+- `gws gmail users messages list --dry-run` の read-only プレビュー
+- エラー分類（認証不備 / コマンド不正 / タイムアウト / 未導入 / 実行失敗）の UI 返却
+
+## 導入手順
+
+`gws` は **オプショナル依存**。未導入でも Mairu の既存機能は利用可能。
+
+### 1. CLI のインストール
+
+```bash
+npm install -g @googleworkspace/cli
+```
+
+または Homebrew:
+
+```bash
+brew install googleworkspace-cli
+```
+
+### 2. 認証（必要に応じて）
+
+```bash
+gws auth setup
+gws auth login
+```
+
+read-only dry-run は環境により認証なしで実行可能だが、実 API 呼び出し検証時は認証済みを推奨。
+
+### 3. Mairu 設定画面での確認
+
+`Settings` 画面の `Google Workspace CLI (gws) PoC` から:
+
+1. `gws 診断を実行`（`--version`）
+2. `Gmail dry-run 候補を取得`（`gmail users messages list --dry-run`）
+
+## 実装ポイント
+
+- Go ラッパー: `internal/gws/client.go`
+- App API:
+  - `CheckGWSDiagnostics()`
+  - `PreviewGWSGmailDryRun(request)`
+- UI:
+  - `frontend/src/pages/Settings/SettingsPage.tsx`
+
+## エラー分類ルール
+
+`gws` の終了コード（README 記載）を優先して分類する。
+
+- `2`: `auth`（認証不備）
+- `3`: `invalid_command`（引数/コマンド不正）
+- context deadline/cancel: `timeout`
+- バイナリ未検出: `not_installed`
+- その他: `execution`
+
+## 制約と注意事項
+
+- `gws` は 0.x 系で、破壊的変更が起きる可能性がある。
+- `gws` は Google の公式サポート製品ではない（community/project ベース）。
+- 本 PoC は `--dry-run` 前提であり、破壊的操作の本実行は対象外。
+- 既存の `internal/gmail` 実装は引き続き正規経路として保持する。
+
+## 今後の判断材料
+
+- `gws` バージョン更新時の追従コスト
+- 認証導線の安定性（ローカル/CI）
+- dry-run 出力の機械可読性（UI の候補提示に必要な情報量）

--- a/frontend/src/lib/runtime.ts
+++ b/frontend/src/lib/runtime.ts
@@ -9,6 +9,8 @@ export type RuntimeStatus = {
     claudeConfigured: boolean;
     claudeStatus: string;
     claudeKeyPreview: string;
+    gwsAvailable: boolean;
+    gwsStatus: string;
     databaseReady: boolean;
     lastRunAt: string | null;
 };
@@ -160,6 +162,39 @@ export type OperationResult = {
     message: string;
 };
 
+export type GWSCLIErrorKind =
+    | 'none'
+    | 'not_installed'
+    | 'auth'
+    | 'invalid_command'
+    | 'timeout'
+    | 'execution';
+
+export type GWSDiagnosticsResult = {
+    success: boolean;
+    available: boolean;
+    message: string;
+    binaryPath: string;
+    version: string;
+    command: string;
+    output: string;
+    errorKind: GWSCLIErrorKind;
+};
+
+export type GWSGmailDryRunRequest = {
+    query: string;
+    maxResults: number;
+};
+
+export type GWSGmailDryRunResult = {
+    success: boolean;
+    message: string;
+    binaryPath: string;
+    command: string;
+    output: string;
+    errorKind: GWSCLIErrorKind;
+};
+
 export type SchedulerSettings = {
     classificationIntervalMinutes: number;
     blocklistIntervalMinutes: number;
@@ -203,6 +238,8 @@ type WailsAppApi = {
               ClaudeConfigured: boolean;
               ClaudeStatus: string;
               ClaudeKeyPreview?: string;
+              GWSAvailable?: boolean;
+              GWSStatus?: string;
               DatabaseReady: boolean;
               LastRunAt?: string | null;
           }>
@@ -217,6 +254,8 @@ type WailsAppApi = {
               ClaudeConfigured: boolean;
               ClaudeStatus: string;
               ClaudeKeyPreview?: string;
+              GWSAvailable?: boolean;
+              GWSStatus?: string;
               DatabaseReady: boolean;
               LastRunAt?: string | null;
           };
@@ -338,6 +377,47 @@ type WailsAppApi = {
               ThreadsTotal?: number;
               HistoryID?: string;
               TokenRefreshed?: boolean;
+          };
+    CheckGWSDiagnostics?: () =>
+        | Promise<{
+              Success: boolean;
+              Available?: boolean;
+              Message: string;
+              BinaryPath?: string;
+              Version?: string;
+              Command?: string;
+              Output?: string;
+              ErrorKind?: GWSCLIErrorKind;
+          }>
+        | {
+              Success: boolean;
+              Available?: boolean;
+              Message: string;
+              BinaryPath?: string;
+              Version?: string;
+              Command?: string;
+              Output?: string;
+              ErrorKind?: GWSCLIErrorKind;
+          };
+    PreviewGWSGmailDryRun?: (request: {
+        Query: string;
+        MaxResults: number;
+    }) =>
+        | Promise<{
+              Success: boolean;
+              Message: string;
+              BinaryPath?: string;
+              Command?: string;
+              Output?: string;
+              ErrorKind?: GWSCLIErrorKind;
+          }>
+        | {
+              Success: boolean;
+              Message: string;
+              BinaryPath?: string;
+              Command?: string;
+              Output?: string;
+              ErrorKind?: GWSCLIErrorKind;
           };
     ExecuteGmailActions?: (request: {
         Confirmed: boolean;
@@ -544,6 +624,8 @@ export const defaultRuntimeStatus: RuntimeStatus = {
     claudeConfigured: false,
     claudeStatus: 'Claude API キー状態を確認しています。',
     claudeKeyPreview: '',
+    gwsAvailable: false,
+    gwsStatus: 'gws は未導入です。必要な場合のみインストールしてください。',
     databaseReady: false,
     lastRunAt: null,
 };
@@ -591,6 +673,8 @@ export async function loadRuntimeStatus(): Promise<RuntimeStatus> {
         claudeConfigured: raw.ClaudeConfigured,
         claudeStatus: raw.ClaudeStatus,
         claudeKeyPreview: raw.ClaudeKeyPreview ?? '',
+        gwsAvailable: raw.GWSAvailable ?? false,
+        gwsStatus: raw.GWSStatus ?? defaultRuntimeStatus.gwsStatus,
         databaseReady: raw.DatabaseReady,
         lastRunAt: raw.LastRunAt ?? null,
     };
@@ -751,6 +835,51 @@ export async function checkGmailConnection(): Promise<GmailConnectionResult> {
         threadsTotal: raw.ThreadsTotal ?? 0,
         historyID: raw.HistoryID ?? '',
         tokenRefreshed: raw.TokenRefreshed ?? false,
+    };
+}
+
+export async function checkGWSDiagnostics(): Promise<GWSDiagnosticsResult> {
+    const appApi = window.go?.main?.App;
+    const result = appApi?.CheckGWSDiagnostics?.();
+
+    if (!result) {
+        throw new Error('gws 診断 API がまだ公開されていません。');
+    }
+
+    const raw = await result;
+    return {
+        success: raw.Success,
+        available: raw.Available ?? false,
+        message: raw.Message,
+        binaryPath: raw.BinaryPath ?? '',
+        version: raw.Version ?? '',
+        command: raw.Command ?? '',
+        output: raw.Output ?? '',
+        errorKind: raw.ErrorKind ?? 'execution',
+    };
+}
+
+export async function previewGWSGmailDryRun(
+    request: GWSGmailDryRunRequest,
+): Promise<GWSGmailDryRunResult> {
+    const appApi = window.go?.main?.App;
+    const result = appApi?.PreviewGWSGmailDryRun?.({
+        Query: request.query,
+        MaxResults: request.maxResults,
+    });
+
+    if (!result) {
+        throw new Error('gws Gmail dry-run API がまだ公開されていません。');
+    }
+
+    const raw = await result;
+    return {
+        success: raw.Success,
+        message: raw.Message,
+        binaryPath: raw.BinaryPath ?? '',
+        command: raw.Command ?? '',
+        output: raw.Output ?? '',
+        errorKind: raw.ErrorKind ?? 'execution',
     };
 }
 

--- a/frontend/src/pages/Settings/SettingsPage.tsx
+++ b/frontend/src/pages/Settings/SettingsPage.tsx
@@ -3,16 +3,20 @@ import './SettingsPage.css';
 import { useEffect, useState } from 'react';
 
 import {
+    checkGWSDiagnostics,
     checkGmailConnection,
     clearClaudeAPIKey,
     cancelGoogleLogin,
     defaultSchedulerSettings,
     getNotificationPermissionStatus,
     loadSchedulerSettings,
+    previewGWSGmailDryRun,
     requestNotificationPermission,
     saveClaudeAPIKey,
     startGoogleLogin,
     updateSchedulerSettings,
+    type GWSDiagnosticsResult,
+    type GWSGmailDryRunResult,
     type GmailConnectionResult,
     type GoogleLoginResult,
     type RuntimeStatus,
@@ -72,6 +76,23 @@ function formatNotificationPermission(permission: NotificationPermission | 'unsu
     }
 }
 
+function formatGWSErrorKind(kind: string): string {
+    switch (kind) {
+        case 'none':
+            return 'なし';
+        case 'not_installed':
+            return '未導入';
+        case 'auth':
+            return '認証不備';
+        case 'invalid_command':
+            return 'コマンド不正';
+        case 'timeout':
+            return 'タイムアウト';
+        default:
+            return '実行失敗';
+    }
+}
+
 export function SettingsPage({ appName, status, onStatusRefresh }: SettingsPageProps) {
     const [loginPending, setLoginPending] = useState(false);
     const [loginError, setLoginError] = useState<string | null>(null);
@@ -80,6 +101,13 @@ export function SettingsPage({ appName, status, onStatusRefresh }: SettingsPageP
     const [gmailPending, setGmailPending] = useState(false);
     const [gmailError, setGmailError] = useState<string | null>(null);
     const [lastGmailResult, setLastGmailResult] = useState<GmailConnectionResult | null>(null);
+    const [gwsDiagnosticPending, setGWSDiagnosticPending] = useState(false);
+    const [gwsDryRunPending, setGWSDryRunPending] = useState(false);
+    const [gwsError, setGWSError] = useState<string | null>(null);
+    const [gwsDiagnosticResult, setGWSDiagnosticResult] = useState<GWSDiagnosticsResult | null>(null);
+    const [gwsDryRunResult, setGWSDryRunResult] = useState<GWSGmailDryRunResult | null>(null);
+    const [gwsQuery, setGWSQuery] = useState('label:inbox is:unread newer_than:7d');
+    const [gwsMaxResults, setGWSMaxResults] = useState(20);
     const [claudeApiKey, setClaudeApiKey] = useState('');
     const [claudePending, setClaudePending] = useState(false);
     const [claudeError, setClaudeError] = useState<string | null>(null);
@@ -305,6 +333,61 @@ export function SettingsPage({ appName, status, onStatusRefresh }: SettingsPageP
         }
     }
 
+    async function handleCheckGWSDiagnostics() {
+        setGWSDiagnosticPending(true);
+        setGWSError(null);
+
+        try {
+            const result = await checkGWSDiagnostics();
+            setGWSDiagnosticResult(result);
+            if (!result.success) {
+                setGWSError(result.message);
+            }
+
+            try {
+                await onStatusRefresh();
+            } catch (cause) {
+                const message =
+                    cause instanceof Error
+                        ? cause.message
+                        : '状態の再取得に失敗しました。';
+                setGWSError((previous) => (previous ? `${previous} / ${message}` : message));
+            }
+        } catch (cause) {
+            const message =
+                cause instanceof Error
+                    ? cause.message
+                    : 'gws 診断に失敗しました。';
+            setGWSError(message);
+        } finally {
+            setGWSDiagnosticPending(false);
+        }
+    }
+
+    async function handlePreviewGWSDryRun() {
+        setGWSDryRunPending(true);
+        setGWSError(null);
+
+        try {
+            const result = await previewGWSGmailDryRun({
+                query: gwsQuery.trim(),
+                maxResults: Math.max(1, gwsMaxResults),
+            });
+            setGWSDryRunResult(result);
+            if (!result.success) {
+                setGWSError(result.message);
+            }
+        } catch (cause) {
+            const message =
+                cause instanceof Error
+                    ? cause.message
+                    : 'gws Gmail dry-run に失敗しました。';
+            setGWSError(message);
+        } finally {
+            setGWSDryRunPending(false);
+        }
+    }
+
     function updateSchedulerInterval(
         key: 'classificationIntervalMinutes' | 'blocklistIntervalMinutes' | 'knownBlockIntervalMinutes',
         value: string,
@@ -397,6 +480,12 @@ export function SettingsPage({ appName, status, onStatusRefresh }: SettingsPageP
                     readyLabel="利用可能"
                     pendingLabel="未初期化"
                     ready={status.databaseReady}
+                />
+                <StatusCard
+                    label="gws CLI"
+                    readyLabel="利用可能"
+                    pendingLabel="未導入"
+                    ready={status.gwsAvailable}
                 />
             </section>
 
@@ -546,6 +635,126 @@ export function SettingsPage({ appName, status, onStatusRefresh }: SettingsPageP
                                 {gmailError ? (
                                     <p className="text-sm leading-7 text-rose-300">{gmailError}</p>
                                 ) : null}
+                            </div>
+                        </li>
+                        <li className="settings-item">
+                            <div className="settings-item-header">
+                                <h3 className="settings-item-title">Google Workspace CLI (`gws`) PoC</h3>
+                                <span className={`state-chip ${status.gwsAvailable ? 'ready' : 'pending'}`}>
+                                    {status.gwsAvailable ? '利用可能' : '未導入'}
+                                </span>
+                            </div>
+                            <p className="settings-item-body">
+                                `gws` は任意導入です。ここでは `--version` 診断と `gmail users messages list --dry-run`
+                                を実行し、既存 Gmail 実装を壊さない PoC 導線を確認できます。
+                            </p>
+                            <div className="settings-action-stack">
+                                <p className="settings-inline-note">{status.gwsStatus}</p>
+                                <div className="settings-action-row">
+                                    <button
+                                        className="settings-action-button"
+                                        type="button"
+                                        onClick={() => {
+                                            void handleCheckGWSDiagnostics();
+                                        }}
+                                        disabled={gwsDiagnosticPending}
+                                    >
+                                        {gwsDiagnosticPending ? '診断中...' : 'gws 診断を実行'}
+                                    </button>
+                                    <button
+                                        className="settings-cancel-button"
+                                        type="button"
+                                        onClick={() => {
+                                            void handlePreviewGWSDryRun();
+                                        }}
+                                        disabled={gwsDryRunPending}
+                                    >
+                                        {gwsDryRunPending ? 'dry-run 実行中...' : 'Gmail dry-run 候補を取得'}
+                                    </button>
+                                </div>
+                                <div className="settings-scheduler-grid">
+                                    <label className="settings-field" htmlFor="gws-query">
+                                        <span className="settings-field-label">Gmail クエリ</span>
+                                        <input
+                                            id="gws-query"
+                                            className="settings-input"
+                                            type="text"
+                                            value={gwsQuery}
+                                            onChange={(event) => {
+                                                setGWSQuery(event.target.value);
+                                            }}
+                                            disabled={gwsDryRunPending}
+                                        />
+                                    </label>
+                                    <label className="settings-field" htmlFor="gws-max-results">
+                                        <span className="settings-field-label">最大件数</span>
+                                        <input
+                                            id="gws-max-results"
+                                            className="settings-input"
+                                            type="number"
+                                            min={1}
+                                            max={100}
+                                            step={1}
+                                            value={gwsMaxResults}
+                                            onChange={(event) => {
+                                                const parsed = Number.parseInt(event.target.value, 10);
+                                                setGWSMaxResults(Number.isFinite(parsed) ? Math.max(1, parsed) : 1);
+                                            }}
+                                            disabled={gwsDryRunPending}
+                                        />
+                                    </label>
+                                </div>
+                                {gwsDiagnosticResult ? (
+                                    <dl className="settings-result-grid">
+                                        <div>
+                                            <dt>診断結果</dt>
+                                            <dd>{gwsDiagnosticResult.message}</dd>
+                                        </div>
+                                        <div>
+                                            <dt>エラー分類</dt>
+                                            <dd>{formatGWSErrorKind(gwsDiagnosticResult.errorKind)}</dd>
+                                        </div>
+                                        <div>
+                                            <dt>バイナリ</dt>
+                                            <dd>{gwsDiagnosticResult.binaryPath || '未検出'}</dd>
+                                        </div>
+                                        <div>
+                                            <dt>バージョン</dt>
+                                            <dd>{gwsDiagnosticResult.version || '未取得'}</dd>
+                                        </div>
+                                        {gwsDiagnosticResult.command ? (
+                                            <div>
+                                                <dt>実行コマンド</dt>
+                                                <dd className="break-all">{gwsDiagnosticResult.command}</dd>
+                                            </div>
+                                        ) : null}
+                                    </dl>
+                                ) : null}
+                                {gwsDryRunResult ? (
+                                    <dl className="settings-result-grid">
+                                        <div>
+                                            <dt>dry-run 結果</dt>
+                                            <dd>{gwsDryRunResult.message}</dd>
+                                        </div>
+                                        <div>
+                                            <dt>エラー分類</dt>
+                                            <dd>{formatGWSErrorKind(gwsDryRunResult.errorKind)}</dd>
+                                        </div>
+                                        {gwsDryRunResult.command ? (
+                                            <div>
+                                                <dt>実行コマンド</dt>
+                                                <dd className="break-all">{gwsDryRunResult.command}</dd>
+                                            </div>
+                                        ) : null}
+                                        <div>
+                                            <dt>コマンド出力</dt>
+                                            <dd className="max-h-56 overflow-auto whitespace-pre-wrap rounded-[14px] border border-slate-400/10 bg-slate-950/45 px-3 py-2 text-xs text-slate-200">
+                                                {gwsDryRunResult.output || '出力なし'}
+                                            </dd>
+                                        </div>
+                                    </dl>
+                                ) : null}
+                                {gwsError ? <p className="settings-error-note">{gwsError}</p> : null}
                             </div>
                         </li>
                         <li className="settings-item">

--- a/internal/gws/client.go
+++ b/internal/gws/client.go
@@ -1,0 +1,336 @@
+package gws
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const (
+	defaultBinaryName  = "gws"
+	defaultMaxResults  = 20
+	minimumMaxResults  = 1
+	maximumMaxResults  = 100
+	defaultGmailUserID = "me"
+)
+
+// ErrorKind は gws 実行失敗時の分類を表す。
+type ErrorKind string
+
+const (
+	ErrorKindNone           ErrorKind = "none"
+	ErrorKindNotInstalled   ErrorKind = "not_installed"
+	ErrorKindAuth           ErrorKind = "auth"
+	ErrorKindInvalidCommand ErrorKind = "invalid_command"
+	ErrorKindTimeout        ErrorKind = "timeout"
+	ErrorKindExecution      ErrorKind = "execution"
+)
+
+// Options は gws クライアント生成時の設定を表す。
+type Options struct {
+	BinaryPath string
+	LookPath   func(string) (string, error)
+}
+
+// Detection は gws バイナリ検出結果を表す。
+type Detection struct {
+	Available  bool
+	BinaryPath string
+	ErrorKind  ErrorKind
+	Message    string
+}
+
+// DiagnoseResult は `gws --version` 実行結果を表す。
+type DiagnoseResult struct {
+	Success    bool
+	Available  bool
+	BinaryPath string
+	Version    string
+	Command    string
+	Output     string
+	ErrorKind  ErrorKind
+	Message    string
+}
+
+// GmailDryRunRequest は Gmail read-only dry-run 実行入力を表す。
+type GmailDryRunRequest struct {
+	Query      string
+	MaxResults int
+}
+
+// GmailDryRunResult は Gmail read-only dry-run 実行結果を表す。
+type GmailDryRunResult struct {
+	Success    bool
+	BinaryPath string
+	Command    string
+	Output     string
+	ErrorKind  ErrorKind
+	Message    string
+}
+
+// Client は gws コマンド実行ラッパー。
+type Client struct {
+	binaryPath string
+	lookPath   func(string) (string, error)
+}
+
+// NewClient は gws 実行クライアントを構築する。
+func NewClient(options Options) *Client {
+	lookPath := options.LookPath
+	if lookPath == nil {
+		lookPath = exec.LookPath
+	}
+
+	return &Client{
+		binaryPath: strings.TrimSpace(options.BinaryPath),
+		lookPath:   lookPath,
+	}
+}
+
+// Detect は gws の導入状態を確認する。
+func (c *Client) Detect() Detection {
+	resolvedPath, err := c.resolveBinaryPath()
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) || errors.Is(err, os.ErrNotExist) {
+			return Detection{
+				Available: false,
+				ErrorKind: ErrorKindNotInstalled,
+				Message:   "gws が見つかりません。PATH へ追加するかインストールしてください。",
+			}
+		}
+
+		return Detection{
+			Available: false,
+			ErrorKind: ErrorKindExecution,
+			Message:   fmt.Sprintf("gws の実行パス確認に失敗しました: %v", err),
+		}
+	}
+
+	return Detection{
+		Available:  true,
+		BinaryPath: resolvedPath,
+		ErrorKind:  ErrorKindNone,
+		Message:    fmt.Sprintf("gws を利用できます (%s)", resolvedPath),
+	}
+}
+
+// Diagnose は `gws --version` を実行し接続診断を返す。
+func (c *Client) Diagnose(ctx context.Context) DiagnoseResult {
+	detection := c.Detect()
+	if !detection.Available {
+		return DiagnoseResult{
+			Success:    false,
+			Available:  false,
+			BinaryPath: "",
+			ErrorKind:  detection.ErrorKind,
+			Message:    detection.Message,
+		}
+	}
+
+	args := []string{"--version"}
+	command := formatCommand(detection.BinaryPath, args)
+	output, errKind, message, runErr := c.run(ctx, detection.BinaryPath, args)
+	if runErr != nil {
+		return DiagnoseResult{
+			Success:    false,
+			Available:  true,
+			BinaryPath: detection.BinaryPath,
+			Command:    command,
+			Output:     output,
+			ErrorKind:  errKind,
+			Message:    message,
+		}
+	}
+
+	version := firstLine(output)
+	if version == "" {
+		version = "unknown"
+	}
+
+	return DiagnoseResult{
+		Success:    true,
+		Available:  true,
+		BinaryPath: detection.BinaryPath,
+		Version:    version,
+		Command:    command,
+		Output:     output,
+		ErrorKind:  ErrorKindNone,
+		Message:    "gws 診断に成功しました。",
+	}
+}
+
+// RunGmailListDryRun は Gmail read-only list コマンドを `--dry-run` で実行する。
+func (c *Client) RunGmailListDryRun(ctx context.Context, request GmailDryRunRequest) GmailDryRunResult {
+	detection := c.Detect()
+	if !detection.Available {
+		return GmailDryRunResult{
+			Success:    false,
+			BinaryPath: "",
+			ErrorKind:  detection.ErrorKind,
+			Message:    detection.Message,
+		}
+	}
+
+	maxResults := normalizeMaxResults(request.MaxResults)
+	params := map[string]any{
+		"userId":     defaultGmailUserID,
+		"maxResults": maxResults,
+	}
+	if query := strings.TrimSpace(request.Query); query != "" {
+		params["q"] = query
+	}
+	paramsJSON, err := json.Marshal(params)
+	if err != nil {
+		return GmailDryRunResult{
+			Success:    false,
+			BinaryPath: detection.BinaryPath,
+			ErrorKind:  ErrorKindExecution,
+			Message:    fmt.Sprintf("gws dry-run のパラメータ生成に失敗しました: %v", err),
+		}
+	}
+
+	args := []string{
+		"gmail", "users", "messages", "list",
+		"--params", string(paramsJSON),
+		"--dry-run",
+	}
+	command := formatCommand(detection.BinaryPath, args)
+	output, errKind, message, runErr := c.run(ctx, detection.BinaryPath, args)
+	if runErr != nil {
+		return GmailDryRunResult{
+			Success:    false,
+			BinaryPath: detection.BinaryPath,
+			Command:    command,
+			Output:     output,
+			ErrorKind:  errKind,
+			Message:    message,
+		}
+	}
+
+	return GmailDryRunResult{
+		Success:    true,
+		BinaryPath: detection.BinaryPath,
+		Command:    command,
+		Output:     output,
+		ErrorKind:  ErrorKindNone,
+		Message:    "gws Gmail dry-run の実行に成功しました。",
+	}
+}
+
+func (c *Client) resolveBinaryPath() (string, error) {
+	configured := strings.TrimSpace(c.binaryPath)
+	if configured == "" {
+		configured = defaultBinaryName
+	}
+
+	if strings.ContainsAny(configured, `/\`) || filepath.IsAbs(configured) {
+		if _, err := os.Stat(configured); err != nil {
+			return "", err
+		}
+		return configured, nil
+	}
+
+	return c.lookPath(configured)
+}
+
+func (c *Client) run(
+	ctx context.Context,
+	binaryPath string,
+	args []string,
+) (output string, errKind ErrorKind, message string, runErr error) {
+	command := exec.CommandContext(ctx, binaryPath, args...)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+
+	err := command.Run()
+	combined := buildCombinedOutput(stdout.String(), stderr.String())
+	if err == nil {
+		return combined, ErrorKindNone, "", nil
+	}
+
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(ctx.Err(), context.Canceled) {
+		return combined, ErrorKindTimeout, "gws 実行がタイムアウトしました。", err
+	}
+
+	if errors.Is(err, exec.ErrNotFound) {
+		return combined, ErrorKindNotInstalled, "gws が見つかりません。", err
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		exitCode := exitErr.ExitCode()
+		errKind := mapExitCode(exitCode)
+		detail := firstLine(strings.TrimSpace(stderr.String()))
+		if detail == "" {
+			detail = firstLine(strings.TrimSpace(stdout.String()))
+		}
+		if detail == "" {
+			detail = fmt.Sprintf("exit code=%d", exitCode)
+		}
+
+		return combined, errKind, fmt.Sprintf("gws コマンドが失敗しました (%s): %s", errKind, detail), err
+	}
+
+	return combined, ErrorKindExecution, fmt.Sprintf("gws コマンドの実行に失敗しました: %v", err), err
+}
+
+func normalizeMaxResults(value int) int {
+	switch {
+	case value < minimumMaxResults:
+		return defaultMaxResults
+	case value > maximumMaxResults:
+		return maximumMaxResults
+	default:
+		return value
+	}
+}
+
+func mapExitCode(code int) ErrorKind {
+	switch code {
+	case 2:
+		return ErrorKindAuth
+	case 3:
+		return ErrorKindInvalidCommand
+	default:
+		return ErrorKindExecution
+	}
+}
+
+func buildCombinedOutput(stdout string, stderr string) string {
+	trimmedStdout := strings.TrimSpace(stdout)
+	trimmedStderr := strings.TrimSpace(stderr)
+	switch {
+	case trimmedStdout != "" && trimmedStderr != "":
+		return trimmedStdout + "\n" + trimmedStderr
+	case trimmedStdout != "":
+		return trimmedStdout
+	default:
+		return trimmedStderr
+	}
+}
+
+func formatCommand(binaryPath string, args []string) string {
+	parts := []string{strconv.Quote(binaryPath)}
+	for _, arg := range args {
+		parts = append(parts, strconv.Quote(arg))
+	}
+	return strings.Join(parts, " ")
+}
+
+func firstLine(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+	lines := strings.Split(trimmed, "\n")
+	return strings.TrimSpace(lines[0])
+}

--- a/internal/gws/client_test.go
+++ b/internal/gws/client_test.go
@@ -1,0 +1,144 @@
+package gws
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDetectReportsNotInstalled(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient(Options{BinaryPath: "definitely-not-found-gws-binary"})
+	result := client.Detect()
+
+	if result.Available {
+		t.Fatalf("Available = true, want false")
+	}
+	if result.ErrorKind != ErrorKindNotInstalled {
+		t.Fatalf("ErrorKind = %q, want %q", result.ErrorKind, ErrorKindNotInstalled)
+	}
+}
+
+func TestDiagnoseReturnsVersion(t *testing.T) {
+	t.Parallel()
+
+	binaryPath := writeExecutableScript(t, `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "gws 0.9.0"
+  exit 0
+fi
+
+echo "unexpected args" >&2
+exit 3
+`)
+	client := NewClient(Options{BinaryPath: binaryPath})
+
+	result := client.Diagnose(context.Background())
+	if !result.Success {
+		t.Fatalf("Success = false, want true (message=%q, output=%q)", result.Message, result.Output)
+	}
+	if result.Version != "gws 0.9.0" {
+		t.Fatalf("Version = %q, want %q", result.Version, "gws 0.9.0")
+	}
+	if result.ErrorKind != ErrorKindNone {
+		t.Fatalf("ErrorKind = %q, want %q", result.ErrorKind, ErrorKindNone)
+	}
+}
+
+func TestRunGmailListDryRunIncludesDryRunAndParams(t *testing.T) {
+	t.Parallel()
+
+	binaryPath := writeExecutableScript(t, `#!/bin/sh
+printf "%s\n" "$@"
+`)
+	client := NewClient(Options{BinaryPath: binaryPath})
+
+	result := client.RunGmailListDryRun(context.Background(), GmailDryRunRequest{
+		Query:      "label:inbox is:unread",
+		MaxResults: 15,
+	})
+	if !result.Success {
+		t.Fatalf("Success = false, want true (message=%q, output=%q)", result.Message, result.Output)
+	}
+
+	if !strings.Contains(result.Output, "--dry-run") {
+		t.Fatalf("Output does not include --dry-run: %q", result.Output)
+	}
+	if !strings.Contains(result.Output, `"userId":"me"`) {
+		t.Fatalf("Output does not include userId=me: %q", result.Output)
+	}
+	if !strings.Contains(result.Output, `"maxResults":15`) {
+		t.Fatalf("Output does not include maxResults=15: %q", result.Output)
+	}
+	if !strings.Contains(result.Output, `"q":"label:inbox is:unread"`) {
+		t.Fatalf("Output does not include q query: %q", result.Output)
+	}
+}
+
+func TestRunGmailListDryRunMapsExitCodeToErrorKind(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		exitCode int
+		wantKind ErrorKind
+	}{
+		{name: "auth", exitCode: 2, wantKind: ErrorKindAuth},
+		{name: "invalid", exitCode: 3, wantKind: ErrorKindInvalidCommand},
+		{name: "execution", exitCode: 5, wantKind: ErrorKindExecution},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			binaryPath := writeExecutableScript(t, "#!/bin/sh\necho 'boom' >&2\nexit "+strconv.Itoa(tt.exitCode)+"\n")
+			client := NewClient(Options{BinaryPath: binaryPath})
+
+			result := client.RunGmailListDryRun(context.Background(), GmailDryRunRequest{})
+			if result.Success {
+				t.Fatalf("Success = true, want false")
+			}
+			if result.ErrorKind != tt.wantKind {
+				t.Fatalf("ErrorKind = %q, want %q", result.ErrorKind, tt.wantKind)
+			}
+		})
+	}
+}
+
+func TestRunGmailListDryRunTimeout(t *testing.T) {
+	t.Parallel()
+
+	binaryPath := writeExecutableScript(t, `#!/bin/sh
+sleep 2
+`)
+	client := NewClient(Options{BinaryPath: binaryPath})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	result := client.RunGmailListDryRun(ctx, GmailDryRunRequest{})
+	if result.Success {
+		t.Fatalf("Success = true, want false")
+	}
+	if result.ErrorKind != ErrorKindTimeout {
+		t.Fatalf("ErrorKind = %q, want %q", result.ErrorKind, ErrorKindTimeout)
+	}
+}
+
+func writeExecutableScript(t *testing.T, content string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gws-test.sh")
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("os.WriteFile returned error: %v", err)
+	}
+	return path
+}

--- a/internal/gws/doc.go
+++ b/internal/gws/doc.go
@@ -1,0 +1,2 @@
+// Package gws は Google Workspace CLI (`gws`) 連携の実行ラッパーを提供する。
+package gws

--- a/internal/types/dto.go
+++ b/internal/types/dto.go
@@ -345,8 +345,50 @@ type RuntimeStatus struct {
 	ClaudeConfigured   bool
 	ClaudeStatus       string
 	ClaudeKeyPreview   string
+	GWSAvailable       bool
+	GWSStatus          string
 	DatabaseReady      bool
 	LastRunAt          *time.Time
+}
+
+// GWSCLIErrorKind は gws 実行失敗時の分類を表す。
+type GWSCLIErrorKind string
+
+const (
+	GWSCLIErrorKindNone           GWSCLIErrorKind = "none"
+	GWSCLIErrorKindNotInstalled   GWSCLIErrorKind = "not_installed"
+	GWSCLIErrorKindAuth           GWSCLIErrorKind = "auth"
+	GWSCLIErrorKindInvalidCommand GWSCLIErrorKind = "invalid_command"
+	GWSCLIErrorKindTimeout        GWSCLIErrorKind = "timeout"
+	GWSCLIErrorKindExecution      GWSCLIErrorKind = "execution"
+)
+
+// GWSDiagnosticsResult は gws 導入診断の結果を表す。
+type GWSDiagnosticsResult struct {
+	Success    bool
+	Available  bool
+	Message    string
+	BinaryPath string
+	Version    string
+	Command    string
+	Output     string
+	ErrorKind  GWSCLIErrorKind
+}
+
+// GWSGmailDryRunRequest は gws Gmail dry-run の入力を表す。
+type GWSGmailDryRunRequest struct {
+	Query      string
+	MaxResults int
+}
+
+// GWSGmailDryRunResult は gws Gmail dry-run の結果を表す。
+type GWSGmailDryRunResult struct {
+	Success    bool
+	Message    string
+	BinaryPath string
+	Command    string
+	Output     string
+	ErrorKind  GWSCLIErrorKind
 }
 
 // SchedulerSettings は定期実行と通知の設定を表す。

--- a/internal/types/dto_test.go
+++ b/internal/types/dto_test.go
@@ -156,3 +156,30 @@ func TestBlocklistKindIsValid(t *testing.T) {
 		t.Fatalf("BlocklistKind(\"unknown\").IsValid() = true, want false")
 	}
 }
+
+func TestGWSCLIErrorKindValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		got  GWSCLIErrorKind
+		want GWSCLIErrorKind
+	}{
+		{name: "none", got: GWSCLIErrorKindNone, want: "none"},
+		{name: "not installed", got: GWSCLIErrorKindNotInstalled, want: "not_installed"},
+		{name: "auth", got: GWSCLIErrorKindAuth, want: "auth"},
+		{name: "invalid command", got: GWSCLIErrorKindInvalidCommand, want: "invalid_command"},
+		{name: "timeout", got: GWSCLIErrorKindTimeout, want: "timeout"},
+		{name: "execution", got: GWSCLIErrorKindExecution, want: "execution"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if tt.got != tt.want {
+				t.Fatalf("unexpected gws error kind value: got %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 関連 Issue
- Closes #46
- Local Issue: MAIRU-023

## 概要
Google Workspace CLI (`gws`) をオプショナル依存で扱う PoC を追加し、既存 Gmail API 実装を維持したまま、Settings 画面から診断と read-only dry-run を確認できるようにしました。

## 詳細設計
- `internal/gws` を新設し、以下を実装
  - `gws --version` 診断
  - `gws gmail users messages list --dry-run` 実行
  - 失敗分類（`not_installed` / `auth` / `invalid_command` / `timeout` / `execution`）
- Go 側 DTO と App API を拡張
  - `RuntimeStatus` に `GWSAvailable`, `GWSStatus` を追加
  - `CheckGWSDiagnostics`, `PreviewGWSGmailDryRun` を追加
- フロント設定画面に最小導線を追加
  - gws 状態表示
  - 診断ボタン
  - Gmail dry-run 実行フォーム（query / maxResults）
  - 実行コマンド・標準出力・エラー分類の表示
- ドキュメント追加
  - `docs/mairu_023_gws_poc.md` に導入手順、制約、今後の判断材料を記載
- `docs/ISSUES.md` の MAIRU-023 状態を `in progress` へ更新

## 実行コマンド
- `gofmt -w app.go app_test.go internal/gws/client.go internal/gws/client_test.go internal/gws/doc.go internal/types/dto.go internal/types/dto_test.go`
- `go test ./...`
- `npm run lint` (frontend)
- `npm run test -- --runInBand` (frontend)
- `npm run build` (frontend)

## テスト結果
- Go テスト: すべて成功
- Frontend 型チェック/テスト: 成功
- Frontend ビルド: 成功
