### PR TITLE
[MAIRU-024 / #48] Classify画面を実メール操作フローへ移行

### DIFF
--- a/app.go
+++ b/app.go
@@ -564,6 +564,120 @@ func (a *App) PreviewGWSGmailDryRun(request types.GWSGmailDryRunRequest) types.G
 	}
 }
 
+// FetchClassificationMessages は Classify 画面向けに Gmail 実メールを取得する。
+func (a *App) FetchClassificationMessages(
+	request types.FetchClassificationMessagesRequest,
+) (types.FetchClassificationMessagesResult, error) {
+	if a.gmailClient == nil {
+		return types.FetchClassificationMessagesResult{}, fmt.Errorf("Gmail クライアントが初期化されていません")
+	}
+
+	baseContext, cancel := context.WithTimeout(a.baseContext(), gmailActionTimeout)
+	defer cancel()
+
+	token, err := a.secretManager.LoadGoogleToken(baseContext)
+	if err != nil {
+		return types.FetchClassificationMessagesResult{}, fmt.Errorf("保存済み Google トークンを読み出せませんでした: %w", err)
+	}
+
+	token, refreshed, err := a.authClient.EnsureValidToken(baseContext, token)
+	if err != nil {
+		return types.FetchClassificationMessagesResult{}, fmt.Errorf("Google トークンを再利用できませんでした: %w", err)
+	}
+	if refreshed {
+		if err := a.secretManager.SaveGoogleToken(baseContext, token); err != nil {
+			return types.FetchClassificationMessagesResult{}, fmt.Errorf("更新した Google トークンをキーチェーンへ保存できませんでした: %w", err)
+		}
+	}
+
+	maxResults := request.MaxResults
+	if maxResults <= 0 || maxResults > types.ClassificationMaxBatchSize {
+		maxResults = types.ClassificationMaxBatchSize
+	}
+
+	result, err := a.gmailClient.FetchMessages(baseContext, token.AccessToken, gmail.FetchRequest{
+		MaxResults: maxResults,
+		LabelIDs:   normalizeLabelIDs(request.LabelIDs),
+		Query:      strings.TrimSpace(request.Query),
+		PageToken:  strings.TrimSpace(request.PageToken),
+	})
+	if err != nil {
+		return types.FetchClassificationMessagesResult{}, fmt.Errorf("Gmail メール取得に失敗しました: %w", err)
+	}
+
+	return types.FetchClassificationMessagesResult{
+		Messages:       result.Messages,
+		NextPageToken:  strings.TrimSpace(result.NextPageToken),
+		TokenRefreshed: refreshed,
+	}, nil
+}
+
+// ListGmailLabels は Classify 画面向けに Gmail ラベル一覧を返す。
+func (a *App) ListGmailLabels() (types.ListGmailLabelsResult, error) {
+	if a.gmailClient == nil {
+		return types.ListGmailLabelsResult{}, fmt.Errorf("Gmail クライアントが初期化されていません")
+	}
+
+	baseContext, cancel := context.WithTimeout(a.baseContext(), gmailActionTimeout)
+	defer cancel()
+
+	token, err := a.secretManager.LoadGoogleToken(baseContext)
+	if err != nil {
+		return types.ListGmailLabelsResult{}, fmt.Errorf("保存済み Google トークンを読み出せませんでした: %w", err)
+	}
+
+	token, refreshed, err := a.authClient.EnsureValidToken(baseContext, token)
+	if err != nil {
+		return types.ListGmailLabelsResult{}, fmt.Errorf("Google トークンを再利用できませんでした: %w", err)
+	}
+	if refreshed {
+		if err := a.secretManager.SaveGoogleToken(baseContext, token); err != nil {
+			return types.ListGmailLabelsResult{}, fmt.Errorf("更新した Google トークンをキーチェーンへ保存できませんでした: %w", err)
+		}
+	}
+
+	labels, err := a.gmailClient.ListLabels(baseContext, token.AccessToken)
+	if err != nil {
+		return types.ListGmailLabelsResult{}, fmt.Errorf("Gmail ラベル一覧取得に失敗しました: %w", err)
+	}
+
+	return types.ListGmailLabelsResult{
+		Labels:         labels,
+		TokenRefreshed: refreshed,
+	}, nil
+}
+
+// FetchGmailMessageDetail は Classify 画面向けに Gmail メール詳細を返す。
+func (a *App) FetchGmailMessageDetail(messageID string) (types.GmailMessageDetail, error) {
+	if a.gmailClient == nil {
+		return types.GmailMessageDetail{}, fmt.Errorf("Gmail クライアントが初期化されていません")
+	}
+
+	baseContext, cancel := context.WithTimeout(a.baseContext(), gmailActionTimeout)
+	defer cancel()
+
+	token, err := a.secretManager.LoadGoogleToken(baseContext)
+	if err != nil {
+		return types.GmailMessageDetail{}, fmt.Errorf("保存済み Google トークンを読み出せませんでした: %w", err)
+	}
+
+	token, refreshed, err := a.authClient.EnsureValidToken(baseContext, token)
+	if err != nil {
+		return types.GmailMessageDetail{}, fmt.Errorf("Google トークンを再利用できませんでした: %w", err)
+	}
+	if refreshed {
+		if err := a.secretManager.SaveGoogleToken(baseContext, token); err != nil {
+			return types.GmailMessageDetail{}, fmt.Errorf("更新した Google トークンをキーチェーンへ保存できませんでした: %w", err)
+		}
+	}
+
+	detail, err := a.gmailClient.FetchMessageDetail(baseContext, token.AccessToken, messageID)
+	if err != nil {
+		return types.GmailMessageDetail{}, fmt.Errorf("Gmail メール詳細取得に失敗しました: %w", err)
+	}
+	return detail, nil
+}
+
 // ExecuteGmailActions は承認済み分類結果を Gmail 側へ反映する。
 func (a *App) ExecuteGmailActions(
 	request types.ExecuteGmailActionsRequest,
@@ -2891,6 +3005,25 @@ func normalizeDomain(raw string) string {
 		return ""
 	}
 	return trimmed
+}
+
+func normalizeLabelIDs(labelIDs []string) []string {
+	normalized := make([]string, 0, len(labelIDs))
+	seen := make(map[string]struct{}, len(labelIDs))
+
+	for _, labelID := range labelIDs {
+		trimmed := strings.TrimSpace(labelID)
+		if trimmed == "" {
+			continue
+		}
+		if _, found := seen[trimmed]; found {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		normalized = append(normalized, trimmed)
+	}
+
+	return normalized
 }
 
 func (a *App) initialAuthStatus() string {

--- a/app.go
+++ b/app.go
@@ -509,6 +509,25 @@ func (a *App) CheckGmailConnection() types.GmailConnectionResult {
 	}
 }
 
+func (a *App) loadUsableGoogleToken(ctx context.Context) (auth.TokenSet, bool, error) {
+	token, err := a.secretManager.LoadGoogleToken(ctx)
+	if err != nil {
+		return auth.TokenSet{}, false, fmt.Errorf("保存済み Google トークンを読み出せませんでした: %w", err)
+	}
+
+	token, refreshed, err := a.authClient.EnsureValidToken(ctx, token)
+	if err != nil {
+		return auth.TokenSet{}, false, fmt.Errorf("Google トークンを再利用できませんでした: %w", err)
+	}
+	if refreshed {
+		if err := a.secretManager.SaveGoogleToken(ctx, token); err != nil {
+			return auth.TokenSet{}, false, fmt.Errorf("更新した Google トークンをキーチェーンへ保存できませんでした: %w", err)
+		}
+	}
+
+	return token, refreshed, nil
+}
+
 // CheckGWSDiagnostics は gws の導入状態とバージョン取得を診断する。
 func (a *App) CheckGWSDiagnostics() types.GWSDiagnosticsResult {
 	if a.gwsClient == nil {
@@ -575,19 +594,9 @@ func (a *App) FetchClassificationMessages(
 	baseContext, cancel := context.WithTimeout(a.baseContext(), gmailActionTimeout)
 	defer cancel()
 
-	token, err := a.secretManager.LoadGoogleToken(baseContext)
+	token, refreshed, err := a.loadUsableGoogleToken(baseContext)
 	if err != nil {
-		return types.FetchClassificationMessagesResult{}, fmt.Errorf("保存済み Google トークンを読み出せませんでした: %w", err)
-	}
-
-	token, refreshed, err := a.authClient.EnsureValidToken(baseContext, token)
-	if err != nil {
-		return types.FetchClassificationMessagesResult{}, fmt.Errorf("Google トークンを再利用できませんでした: %w", err)
-	}
-	if refreshed {
-		if err := a.secretManager.SaveGoogleToken(baseContext, token); err != nil {
-			return types.FetchClassificationMessagesResult{}, fmt.Errorf("更新した Google トークンをキーチェーンへ保存できませんでした: %w", err)
-		}
+		return types.FetchClassificationMessagesResult{}, err
 	}
 
 	maxResults := request.MaxResults
@@ -621,19 +630,9 @@ func (a *App) ListGmailLabels() (types.ListGmailLabelsResult, error) {
 	baseContext, cancel := context.WithTimeout(a.baseContext(), gmailActionTimeout)
 	defer cancel()
 
-	token, err := a.secretManager.LoadGoogleToken(baseContext)
+	token, refreshed, err := a.loadUsableGoogleToken(baseContext)
 	if err != nil {
-		return types.ListGmailLabelsResult{}, fmt.Errorf("保存済み Google トークンを読み出せませんでした: %w", err)
-	}
-
-	token, refreshed, err := a.authClient.EnsureValidToken(baseContext, token)
-	if err != nil {
-		return types.ListGmailLabelsResult{}, fmt.Errorf("Google トークンを再利用できませんでした: %w", err)
-	}
-	if refreshed {
-		if err := a.secretManager.SaveGoogleToken(baseContext, token); err != nil {
-			return types.ListGmailLabelsResult{}, fmt.Errorf("更新した Google トークンをキーチェーンへ保存できませんでした: %w", err)
-		}
+		return types.ListGmailLabelsResult{}, err
 	}
 
 	labels, err := a.gmailClient.ListLabels(baseContext, token.AccessToken)
@@ -656,19 +655,9 @@ func (a *App) FetchGmailMessageDetail(messageID string) (types.GmailMessageDetai
 	baseContext, cancel := context.WithTimeout(a.baseContext(), gmailActionTimeout)
 	defer cancel()
 
-	token, err := a.secretManager.LoadGoogleToken(baseContext)
+	token, _, err := a.loadUsableGoogleToken(baseContext)
 	if err != nil {
-		return types.GmailMessageDetail{}, fmt.Errorf("保存済み Google トークンを読み出せませんでした: %w", err)
-	}
-
-	token, refreshed, err := a.authClient.EnsureValidToken(baseContext, token)
-	if err != nil {
-		return types.GmailMessageDetail{}, fmt.Errorf("Google トークンを再利用できませんでした: %w", err)
-	}
-	if refreshed {
-		if err := a.secretManager.SaveGoogleToken(baseContext, token); err != nil {
-			return types.GmailMessageDetail{}, fmt.Errorf("更新した Google トークンをキーチェーンへ保存できませんでした: %w", err)
-		}
+		return types.GmailMessageDetail{}, err
 	}
 
 	detail, err := a.gmailClient.FetchMessageDetail(baseContext, token.AccessToken, messageID)
@@ -698,19 +687,9 @@ func (a *App) ExecuteGmailActions(
 	baseContext, cancel := context.WithTimeout(a.baseContext(), gmailActionTimeout)
 	defer cancel()
 
-	token, err := a.secretManager.LoadGoogleToken(baseContext)
+	token, refreshed, err := a.loadUsableGoogleToken(baseContext)
 	if err != nil {
-		return types.ExecuteGmailActionsResult{}, fmt.Errorf("保存済み Google トークンを読み出せませんでした: %w", err)
-	}
-
-	token, refreshed, err := a.authClient.EnsureValidToken(baseContext, token)
-	if err != nil {
-		return types.ExecuteGmailActionsResult{}, fmt.Errorf("Google トークンを再利用できませんでした: %w", err)
-	}
-	if refreshed {
-		if err := a.secretManager.SaveGoogleToken(baseContext, token); err != nil {
-			return types.ExecuteGmailActionsResult{}, fmt.Errorf("更新した Google トークンをキーチェーンへ保存できませんでした: %w", err)
-		}
+		return types.ExecuteGmailActionsResult{}, err
 	}
 
 	store, storeErr := a.requireDBStore()

--- a/app_test.go
+++ b/app_test.go
@@ -236,6 +236,310 @@ func TestCheckGmailConnectionRefreshesStoredToken(t *testing.T) {
 	}
 }
 
+func TestFetchClassificationMessagesUsesFetchConditions(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := auth.NewMemorySecretStore()
+	manager := auth.NewSecretManager(store)
+	if err := manager.SaveGoogleToken(ctx, auth.TokenSet{AccessToken: "access-token"}); err != nil {
+		t.Fatalf("SaveGoogleToken returned error: %v", err)
+	}
+
+	httpClient := &http.Client{
+		Transport: appRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+			switch r.URL.Path {
+			case "/gmail/v1/users/me/messages":
+				if got := r.URL.Query().Get("maxResults"); got != "25" {
+					t.Fatalf("maxResults = %q, want %q", got, "25")
+				}
+				if got := r.URL.Query().Get("q"); got != "newer_than:7d -category:promotions" {
+					t.Fatalf("q = %q, want %q", got, "newer_than:7d -category:promotions")
+				}
+				if got := r.URL.Query().Get("pageToken"); got != "page-2" {
+					t.Fatalf("pageToken = %q, want %q", got, "page-2")
+				}
+				gotLabelIDs := r.URL.Query()["labelIds"]
+				if len(gotLabelIDs) != 2 {
+					t.Fatalf("len(labelIds) = %d, want 2", len(gotLabelIDs))
+				}
+				if gotLabelIDs[0] != "INBOX" || gotLabelIDs[1] != "LabelImportant" {
+					t.Fatalf("labelIds = %v, want [INBOX LabelImportant]", gotLabelIDs)
+				}
+				if got := r.Header.Get("Authorization"); got != "Bearer access-token" {
+					t.Fatalf("Authorization = %q, want %q", got, "Bearer access-token")
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+					Body: io.NopCloser(strings.NewReader(`{
+						"messages":[{"id":"msg-1","threadId":"thread-1"}],
+						"nextPageToken":"next-page"
+					}`)),
+				}, nil
+			case "/gmail/v1/users/me/messages/msg-1":
+				if got := r.Header.Get("Authorization"); got != "Bearer access-token" {
+					t.Fatalf("Authorization = %q, want %q", got, "Bearer access-token")
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+					Body: io.NopCloser(strings.NewReader(`{
+						"id":"msg-1",
+						"threadId":"thread-1",
+						"snippet":"message snippet",
+						"labelIds":["INBOX","UNREAD"],
+						"payload":{"headers":[
+							{"name":"From","value":"sender@example.com"},
+							{"name":"Subject","value":"subject line"}
+						]}
+					}`)),
+				}, nil
+			default:
+				t.Fatalf("unexpected URL: %s", r.URL.String())
+				return nil, nil
+			}
+		}),
+	}
+
+	app := &App{
+		authClient:    auth.NewClient(auth.Config{}),
+		gmailClient:   gmail.NewClient(gmail.Options{BaseURL: "https://gmail.test", HTTPClient: httpClient}),
+		secretManager: manager,
+	}
+
+	result, err := app.FetchClassificationMessages(types.FetchClassificationMessagesRequest{
+		Query:      " newer_than:7d -category:promotions ",
+		MaxResults: 25,
+		LabelIDs:   []string{" INBOX ", "", "LabelImportant", "INBOX"},
+		PageToken:  " page-2 ",
+	})
+	if err != nil {
+		t.Fatalf("FetchClassificationMessages returned error: %v", err)
+	}
+	if result.TokenRefreshed {
+		t.Fatalf("TokenRefreshed = true, want false")
+	}
+	if result.NextPageToken != "next-page" {
+		t.Fatalf("NextPageToken = %q, want %q", result.NextPageToken, "next-page")
+	}
+	if len(result.Messages) != 1 {
+		t.Fatalf("len(Messages) = %d, want 1", len(result.Messages))
+	}
+	if result.Messages[0].ID != "msg-1" {
+		t.Fatalf("Messages[0].ID = %q, want %q", result.Messages[0].ID, "msg-1")
+	}
+	if !result.Messages[0].Unread {
+		t.Fatalf("Messages[0].Unread = false, want true")
+	}
+}
+
+func TestFetchClassificationMessagesRefreshesStoredToken(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := auth.NewMemorySecretStore()
+	manager := auth.NewSecretManager(store)
+	if err := manager.SaveGoogleToken(ctx, auth.TokenSet{
+		AccessToken:  "expired-access-token",
+		RefreshToken: "refresh-token",
+		Expiry:       time.Now().UTC().Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("SaveGoogleToken returned error: %v", err)
+	}
+
+	httpClient := &http.Client{
+		Transport: appRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+			switch r.URL.String() {
+			case "https://oauth.test/token":
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+					Body: io.NopCloser(strings.NewReader(`{
+						"access_token":"fresh-access-token",
+						"expires_in":3600
+					}`)),
+				}, nil
+			case "https://gmail.test/gmail/v1/users/me/messages?maxResults=50":
+				if got := r.Header.Get("Authorization"); got != "Bearer fresh-access-token" {
+					t.Fatalf("Authorization = %q, want %q", got, "Bearer fresh-access-token")
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+					Body: io.NopCloser(strings.NewReader(`{"messages":[]}`)),
+				}, nil
+			default:
+				t.Fatalf("unexpected URL: %s", r.URL.String())
+				return nil, nil
+			}
+		}),
+	}
+
+	app := &App{
+		authClient: auth.NewClient(auth.Config{
+			ClientID:     "client-id",
+			ClientSecret: "client-secret",
+			TokenURL:     "https://oauth.test/token",
+			HTTPClient:   httpClient,
+		}),
+		gmailClient:   gmail.NewClient(gmail.Options{BaseURL: "https://gmail.test", HTTPClient: httpClient}),
+		secretManager: manager,
+	}
+
+	result, err := app.FetchClassificationMessages(types.FetchClassificationMessagesRequest{})
+	if err != nil {
+		t.Fatalf("FetchClassificationMessages returned error: %v", err)
+	}
+	if !result.TokenRefreshed {
+		t.Fatalf("TokenRefreshed = false, want true")
+	}
+
+	stored, err := manager.LoadGoogleToken(ctx)
+	if err != nil {
+		t.Fatalf("LoadGoogleToken returned error: %v", err)
+	}
+	if stored.AccessToken != "fresh-access-token" {
+		t.Fatalf("stored AccessToken = %q, want %q", stored.AccessToken, "fresh-access-token")
+	}
+}
+
+func TestListGmailLabelsReturnsLabels(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := auth.NewMemorySecretStore()
+	manager := auth.NewSecretManager(store)
+	if err := manager.SaveGoogleToken(ctx, auth.TokenSet{AccessToken: "access-token"}); err != nil {
+		t.Fatalf("SaveGoogleToken returned error: %v", err)
+	}
+
+	httpClient := &http.Client{
+		Transport: appRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if r.URL.String() != "https://gmail.test/gmail/v1/users/me/labels" {
+				t.Fatalf("unexpected URL: %s", r.URL.String())
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer access-token" {
+				t.Fatalf("Authorization = %q, want %q", got, "Bearer access-token")
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				Body: io.NopCloser(strings.NewReader(`{
+					"labels":[
+						{"id":"LabelImportant","name":"Mairu/Important","type":"user"},
+						{"id":"INBOX","name":"INBOX","type":"system"}
+					]
+				}`)),
+			}, nil
+		}),
+	}
+
+	app := &App{
+		authClient:    auth.NewClient(auth.Config{}),
+		gmailClient:   gmail.NewClient(gmail.Options{BaseURL: "https://gmail.test", HTTPClient: httpClient}),
+		secretManager: manager,
+	}
+
+	result, err := app.ListGmailLabels()
+	if err != nil {
+		t.Fatalf("ListGmailLabels returned error: %v", err)
+	}
+	if result.TokenRefreshed {
+		t.Fatalf("TokenRefreshed = true, want false")
+	}
+	if len(result.Labels) != 2 {
+		t.Fatalf("len(Labels) = %d, want 2", len(result.Labels))
+	}
+	if result.Labels[0].ID != "INBOX" {
+		t.Fatalf("Labels[0].ID = %q, want %q", result.Labels[0].ID, "INBOX")
+	}
+	if result.Labels[1].ID != "LabelImportant" {
+		t.Fatalf("Labels[1].ID = %q, want %q", result.Labels[1].ID, "LabelImportant")
+	}
+}
+
+func TestFetchGmailMessageDetailReturnsMessageDetail(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := auth.NewMemorySecretStore()
+	manager := auth.NewSecretManager(store)
+	if err := manager.SaveGoogleToken(ctx, auth.TokenSet{AccessToken: "access-token"}); err != nil {
+		t.Fatalf("SaveGoogleToken returned error: %v", err)
+	}
+
+	httpClient := &http.Client{
+		Transport: appRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if r.URL.String() != "https://gmail.test/gmail/v1/users/me/messages/msg-1?format=full" {
+				t.Fatalf("unexpected URL: %s", r.URL.String())
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer access-token" {
+				t.Fatalf("Authorization = %q, want %q", got, "Bearer access-token")
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				Body: io.NopCloser(strings.NewReader(`{
+					"id":"msg-1",
+					"threadId":"thread-1",
+					"snippet":"snippet text",
+					"labelIds":["INBOX","UNREAD"],
+					"payload":{
+						"mimeType":"text/plain",
+						"headers":[
+							{"name":"From","value":"sender@example.com"},
+							{"name":"To","value":"user@example.com"},
+							{"name":"Subject","value":"subject line"}
+						],
+						"body":{"data":"SGVsbG8gcGxhaW4gYm9keQ"}
+					}
+				}`)),
+			}, nil
+		}),
+	}
+
+	app := &App{
+		authClient:    auth.NewClient(auth.Config{}),
+		gmailClient:   gmail.NewClient(gmail.Options{BaseURL: "https://gmail.test", HTTPClient: httpClient}),
+		secretManager: manager,
+	}
+
+	result, err := app.FetchGmailMessageDetail("msg-1")
+	if err != nil {
+		t.Fatalf("FetchGmailMessageDetail returned error: %v", err)
+	}
+	if result.ID != "msg-1" {
+		t.Fatalf("ID = %q, want %q", result.ID, "msg-1")
+	}
+	if result.ThreadID != "thread-1" {
+		t.Fatalf("ThreadID = %q, want %q", result.ThreadID, "thread-1")
+	}
+	if result.Subject != "subject line" {
+		t.Fatalf("Subject = %q, want %q", result.Subject, "subject line")
+	}
+	if result.BodyText != "Hello plain body" {
+		t.Fatalf("BodyText = %q, want %q", result.BodyText, "Hello plain body")
+	}
+	if !result.Unread {
+		t.Fatalf("Unread = false, want true")
+	}
+}
+
 func TestGetRuntimeStatusClearsGmailSuccessWhenUnauthorized(t *testing.T) {
 	t.Parallel()
 

--- a/frontend/src/lib/runtime.ts
+++ b/frontend/src/lib/runtime.ts
@@ -82,6 +82,50 @@ export type GmailConnectionResult = {
     tokenRefreshed: boolean;
 };
 
+export type FetchClassificationMessagesRequest = {
+    query: string;
+    maxResults: number;
+    labelIDs: string[];
+    pageToken?: string;
+};
+
+export type FetchClassificationMessagesResult = {
+    messages: EmailSummary[];
+    nextPageToken: string;
+    tokenRefreshed: boolean;
+};
+
+export type GmailLabel = {
+    id: string;
+    name: string;
+    type: string;
+};
+
+export type ListGmailLabelsResult = {
+    labels: GmailLabel[];
+    tokenRefreshed: boolean;
+};
+
+export type GmailMessageHeader = {
+    name: string;
+    value: string;
+};
+
+export type GmailMessageDetail = {
+    id: string;
+    threadID: string;
+    from: string;
+    to: string;
+    subject: string;
+    date: string;
+    snippet: string;
+    labelIDs: string[];
+    unread: boolean;
+    bodyText: string;
+    bodyHTML: string;
+    headers: GmailMessageHeader[];
+};
+
 export type GmailActionDecision = {
     messageID: string;
     category: ClassificationCategory;
@@ -357,6 +401,88 @@ type WailsAppApi = {
                   Reason: string;
                   ReviewLevel: ClassificationReviewLevel;
                   Source?: 'claude' | 'blocklist';
+              }>;
+          };
+    FetchClassificationMessages?: (request: {
+        Query: string;
+        MaxResults: number;
+        LabelIDs?: string[];
+        PageToken?: string;
+    }) =>
+        | Promise<{
+              Messages?: Array<{
+                  ID: string;
+                  ThreadID?: string;
+                  From: string;
+                  Subject: string;
+                  Snippet: string;
+                  Unread: boolean;
+              }>;
+              NextPageToken?: string;
+              TokenRefreshed?: boolean;
+          }>
+        | {
+              Messages?: Array<{
+                  ID: string;
+                  ThreadID?: string;
+                  From: string;
+                  Subject: string;
+                  Snippet: string;
+                  Unread: boolean;
+              }>;
+              NextPageToken?: string;
+              TokenRefreshed?: boolean;
+          };
+    ListGmailLabels?: () =>
+        | Promise<{
+              Labels?: Array<{
+                  ID: string;
+                  Name: string;
+                  Type?: string;
+              }>;
+              TokenRefreshed?: boolean;
+          }>
+        | {
+              Labels?: Array<{
+                  ID: string;
+                  Name: string;
+                  Type?: string;
+              }>;
+              TokenRefreshed?: boolean;
+          };
+    FetchGmailMessageDetail?: (messageID: string) =>
+        | Promise<{
+              ID?: string;
+              ThreadID?: string;
+              From?: string;
+              To?: string;
+              Subject?: string;
+              Date?: string;
+              Snippet?: string;
+              LabelIDs?: string[];
+              Unread?: boolean;
+              BodyText?: string;
+              BodyHTML?: string;
+              Headers?: Array<{
+                  Name: string;
+                  Value: string;
+              }>;
+          }>
+        | {
+              ID?: string;
+              ThreadID?: string;
+              From?: string;
+              To?: string;
+              Subject?: string;
+              Date?: string;
+              Snippet?: string;
+              LabelIDs?: string[];
+              Unread?: boolean;
+              BodyText?: string;
+              BodyHTML?: string;
+              Headers?: Array<{
+                  Name: string;
+                  Value: string;
               }>;
           };
     CheckGmailConnection?: () =>
@@ -814,6 +940,83 @@ export async function classifyEmails(request: ClassificationRequest): Promise<Cl
             reason: item.Reason,
             reviewLevel: item.ReviewLevel,
             source: item.Source ?? 'claude',
+        })),
+    };
+}
+
+export async function fetchClassificationMessages(
+    request: FetchClassificationMessagesRequest,
+): Promise<FetchClassificationMessagesResult> {
+    const appApi = window.go?.main?.App;
+    const result = appApi?.FetchClassificationMessages?.({
+        Query: request.query,
+        MaxResults: request.maxResults,
+        LabelIDs: request.labelIDs,
+        PageToken: request.pageToken,
+    });
+
+    if (!result) {
+        throw new Error('実メール取得 API がまだ公開されていません。');
+    }
+
+    const raw = await result;
+    return {
+        messages: (raw.Messages ?? []).map((item) => ({
+            id: item.ID,
+            threadID: item.ThreadID ?? '',
+            from: item.From,
+            subject: item.Subject,
+            snippet: item.Snippet,
+            unread: item.Unread,
+        })),
+        nextPageToken: raw.NextPageToken ?? '',
+        tokenRefreshed: raw.TokenRefreshed ?? false,
+    };
+}
+
+export async function listGmailLabels(): Promise<ListGmailLabelsResult> {
+    const appApi = window.go?.main?.App;
+    const result = appApi?.ListGmailLabels?.();
+
+    if (!result) {
+        throw new Error('Gmail ラベル一覧取得 API がまだ公開されていません。');
+    }
+
+    const raw = await result;
+    return {
+        labels: (raw.Labels ?? []).map((item) => ({
+            id: item.ID,
+            name: item.Name,
+            type: item.Type ?? '',
+        })),
+        tokenRefreshed: raw.TokenRefreshed ?? false,
+    };
+}
+
+export async function fetchGmailMessageDetail(messageID: string): Promise<GmailMessageDetail> {
+    const appApi = window.go?.main?.App;
+    const result = appApi?.FetchGmailMessageDetail?.(messageID);
+
+    if (!result) {
+        throw new Error('Gmail メール詳細取得 API がまだ公開されていません。');
+    }
+
+    const raw = await result;
+    return {
+        id: raw.ID ?? messageID,
+        threadID: raw.ThreadID ?? '',
+        from: raw.From ?? '',
+        to: raw.To ?? '',
+        subject: raw.Subject ?? '',
+        date: raw.Date ?? '',
+        snippet: raw.Snippet ?? '',
+        labelIDs: raw.LabelIDs ?? [],
+        unread: raw.Unread ?? false,
+        bodyText: raw.BodyText ?? '',
+        bodyHTML: raw.BodyHTML ?? '',
+        headers: (raw.Headers ?? []).map((header) => ({
+            name: header.Name,
+            value: header.Value,
         })),
     };
 }

--- a/frontend/src/pages/Classify/ClassifyPage.css
+++ b/frontend/src/pages/Classify/ClassifyPage.css
@@ -63,6 +63,7 @@
 
 .classify-controls,
 .classify-actions,
+.classify-fetched,
 .classify-results {
     padding: 20px;
     border-radius: 20px;
@@ -77,9 +78,28 @@
     align-items: end;
 }
 
+.classify-fetch-row {
+    grid-template-columns:
+        minmax(220px, 1.6fr)
+        minmax(120px, 0.7fr)
+        minmax(220px, 1.2fr)
+        auto
+        auto
+        auto;
+}
+
+.classify-model-row {
+    margin-top: 10px;
+    grid-template-columns: minmax(220px, 1fr) auto;
+}
+
 .classify-field {
     display: grid;
     gap: 7px;
+}
+
+.classify-field-sm input {
+    min-width: 0;
 }
 
 .classify-field span {
@@ -188,6 +208,13 @@
     flex-wrap: wrap;
 }
 
+.classify-actions-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: flex-end;
+}
+
 .classify-actions-header h2 {
     margin: 0;
     font-size: 1.15rem;
@@ -206,6 +233,20 @@
     border-radius: 14px;
     border: 1px solid rgba(148, 163, 184, 0.16);
     background: rgba(2, 6, 23, 0.3);
+}
+
+.classify-confirm-panel {
+    margin-top: 12px;
+    padding: 12px;
+    border-radius: 14px;
+    border: 1px solid rgba(125, 211, 252, 0.4);
+    background: rgba(2, 132, 199, 0.12);
+}
+
+.classify-confirm-panel p {
+    margin: 0 0 10px;
+    color: #dbeafe;
+    line-height: 1.6;
 }
 
 .classify-action-stats {
@@ -239,6 +280,26 @@
     color: #fecaca;
     line-height: 1.6;
     font-size: 0.86rem;
+}
+
+.classify-history {
+    margin-top: 12px;
+    padding-top: 10px;
+    border-top: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.classify-history h3 {
+    margin: 0;
+    font-size: 0.9rem;
+    color: #cbd5e1;
+}
+
+.classify-history ul {
+    margin: 8px 0 0;
+    padding-left: 18px;
+    color: #cbd5e1;
+    line-height: 1.6;
+    font-size: 0.84rem;
 }
 
 .classify-results-header {
@@ -324,6 +385,10 @@
     line-height: 1.5;
 }
 
+.classify-id {
+    word-break: break-all;
+}
+
 .result-primary {
     color: #f8fafc;
     font-weight: 600;
@@ -356,6 +421,27 @@
     border-radius: 999px;
     font-size: 0.72rem;
     font-weight: 700;
+}
+
+.unread-chip {
+    margin: 0;
+    display: inline-flex;
+    align-items: center;
+    width: fit-content;
+    padding: 4px 8px;
+    border-radius: 999px;
+    font-size: 0.72rem;
+    font-weight: 700;
+}
+
+.unread-chip.unread {
+    color: #083344;
+    background: #a5f3fc;
+}
+
+.unread-chip.read {
+    color: #334155;
+    background: #cbd5e1;
 }
 
 .source-claude {
@@ -466,6 +552,138 @@
     color: #cbd5e1;
 }
 
+.classify-devtools {
+    margin-top: 12px;
+    border-radius: 12px;
+    border: 1px solid rgba(148, 163, 184, 0.16);
+    background: rgba(2, 6, 23, 0.24);
+    padding: 10px 12px;
+}
+
+.classify-devtools summary {
+    cursor: pointer;
+    color: #cbd5e1;
+    font-size: 0.86rem;
+    font-weight: 700;
+}
+
+.classify-devtools-actions {
+    margin-top: 10px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.classify-message-detail {
+    margin-top: 14px;
+    padding: 12px;
+    border-radius: 14px;
+    border: 1px solid rgba(148, 163, 184, 0.16);
+    background: rgba(2, 6, 23, 0.3);
+}
+
+.classify-message-detail-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.classify-message-detail-header h3 {
+    margin: 0;
+    font-size: 1rem;
+}
+
+.classify-message-meta {
+    margin: 10px 0 0;
+    display: grid;
+    gap: 8px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.classify-message-meta div {
+    display: grid;
+    gap: 2px;
+}
+
+.classify-message-meta dt {
+    color: #94a3b8;
+    font-size: 0.75rem;
+}
+
+.classify-message-meta dd {
+    margin: 0;
+    color: #f8fafc;
+    line-height: 1.5;
+}
+
+.classify-message-detail details {
+    margin-top: 10px;
+    border-top: 1px solid rgba(148, 163, 184, 0.16);
+    padding-top: 8px;
+}
+
+.classify-message-detail summary {
+    cursor: pointer;
+    color: #cbd5e1;
+    font-size: 0.86rem;
+    font-weight: 700;
+}
+
+.classify-message-body {
+    margin: 8px 0 0;
+    max-height: 280px;
+    overflow: auto;
+    padding: 10px;
+    border-radius: 10px;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    background: rgba(15, 23, 42, 0.6);
+    color: #e2e8f0;
+    font-size: 0.82rem;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.classify-header-list {
+    margin: 8px 0 0;
+    padding-left: 18px;
+    color: #cbd5e1;
+    font-size: 0.82rem;
+    line-height: 1.6;
+}
+
+.header-name {
+    color: #e2e8f0;
+    font-weight: 700;
+}
+
+.header-value {
+    word-break: break-word;
+}
+
+.classify-label-select {
+    width: 100%;
+    min-width: 220px;
+    padding: 8px 10px;
+    border-radius: 12px;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    background: rgba(2, 6, 23, 0.42);
+    color: #f8fafc;
+    font: inherit;
+}
+
+.classify-label-select:focus-visible {
+    outline: 2px solid #bae6fd;
+    outline-offset: 2px;
+}
+
+.classify-label-select:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+}
+
 @media (max-width: 980px) {
     .classify-summary {
         grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -480,6 +698,7 @@
     .classify-hero,
     .classify-controls,
     .classify-actions,
+    .classify-fetched,
     .classify-results {
         padding: 16px;
     }

--- a/frontend/src/pages/Classify/ClassifyPage.css
+++ b/frontend/src/pages/Classify/ClassifyPage.css
@@ -643,7 +643,7 @@
     font-size: 0.82rem;
     line-height: 1.5;
     white-space: pre-wrap;
-    word-break: break-word;
+    overflow-wrap: anywhere;
 }
 
 .classify-header-list {
@@ -660,7 +660,7 @@
 }
 
 .header-value {
-    word-break: break-word;
+    overflow-wrap: anywhere;
 }
 
 .classify-label-select {

--- a/frontend/src/pages/Classify/ClassifyPage.tsx
+++ b/frontend/src/pages/Classify/ClassifyPage.tsx
@@ -1,16 +1,21 @@
 import './ClassifyPage.css';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import {
     classifyEmails,
+    fetchClassificationMessages,
+    fetchGmailMessageDetail,
+    listGmailLabels,
     type ClassificationCategory,
     type ClassificationResponse,
     type ClassificationReviewLevel,
     type EmailSummary,
     executeGmailActions,
-    recordClassificationRun,
+    type GmailLabel,
+    type GmailMessageDetail,
     recordClassificationCorrection,
+    recordClassificationRun,
     type ExecuteGmailActionsResult,
     type RuntimeStatus,
 } from '../../lib/runtime';
@@ -26,7 +31,15 @@ type ClassifiedRow = {
     message: EmailSummary | undefined;
 };
 
-const sampleMessageCount = 50;
+type ActionExecutionHistory = {
+    at: string;
+    selectedCount: number;
+    result: ExecuteGmailActionsResult;
+};
+
+const maxFetchCount = 50;
+const defaultFetchCount = 50;
+const defaultLabelID = 'INBOX';
 
 const sampleSenders = [
     'alerts@bank.example',
@@ -195,7 +208,7 @@ function recommendedAction(
     }
 }
 
-function formatClassifiedAt(value: string | null): string {
+function formatDateTime(value: string | null): string {
     if (!value) {
         return '未実行';
     }
@@ -226,29 +239,114 @@ function actionKindLabel(action: 'label' | 'archive' | 'delete' | 'mark_read'): 
     }
 }
 
+function normalizeFetchCount(value: number): number {
+    if (!Number.isFinite(value)) {
+        return defaultFetchCount;
+    }
+    const rounded = Math.round(value);
+    if (rounded < 1) {
+        return 1;
+    }
+    if (rounded > maxFetchCount) {
+        return maxFetchCount;
+    }
+    return rounded;
+}
+
+function normalizeFetchCountInput(value: string): string {
+    return String(normalizeFetchCount(Number(value)));
+}
+
+function extractErrorMessage(cause: unknown, fallback: string): string {
+    if (cause instanceof Error) {
+        const message = cause.message.trim();
+        if (message !== '') {
+            return message;
+        }
+    }
+    if (typeof cause === 'string') {
+        const message = cause.trim();
+        if (message !== '') {
+            return message;
+        }
+    }
+    if (cause && typeof cause === 'object') {
+        const withMessage = cause as { message?: unknown; error?: unknown };
+        if (typeof withMessage.message === 'string' && withMessage.message.trim() !== '') {
+            return withMessage.message.trim();
+        }
+        if (typeof withMessage.error === 'string' && withMessage.error.trim() !== '') {
+            return withMessage.error.trim();
+        }
+        try {
+            const serialized = JSON.stringify(cause);
+            if (serialized && serialized !== '{}') {
+                return serialized;
+            }
+        } catch {
+            // ignore serialization errors and use fallback
+        }
+    }
+    return fallback;
+}
+
+function buildSampleMessageDetail(message: EmailSummary): GmailMessageDetail {
+    return {
+        id: message.id,
+        threadID: message.threadID,
+        from: message.from,
+        to: '',
+        subject: message.subject,
+        date: '',
+        snippet: message.snippet,
+        labelIDs: message.unread ? ['INBOX', 'UNREAD'] : ['INBOX'],
+        unread: message.unread,
+        bodyText: message.snippet,
+        bodyHTML: '',
+        headers: [
+            { name: 'From', value: message.from },
+            { name: 'Subject', value: message.subject },
+        ],
+    };
+}
+
 export function ClassifyPage({ status }: ClassifyPageProps) {
-    const [messages, setMessages] = useState<EmailSummary[]>(() =>
-        buildSampleMessages(sampleMessageCount));
-    const [results, setResults] = useState<ClassificationResponse['results']>(() =>
-        buildMockResults(buildSampleMessages(sampleMessageCount)));
+    const [messages, setMessages] = useState<EmailSummary[]>([]);
+    const [results, setResults] = useState<ClassificationResponse['results']>([]);
     const [filter, setFilter] = useState<ReviewFilter>('all');
     const [selectedForApproval, setSelectedForApproval] = useState<Record<string, boolean>>({});
     const [correctedCategories, setCorrectedCategories] = useState<
         Record<string, ClassificationCategory>
     >({});
     const [classifyModel, setClassifyModel] = useState('');
+    const [fetchQuery, setFetchQuery] = useState('');
+    const [fetchCountInput, setFetchCountInput] = useState(String(defaultFetchCount));
+    const [selectedLabelIDs, setSelectedLabelIDs] = useState<string[]>([defaultLabelID]);
+    const [availableLabels, setAvailableLabels] = useState<GmailLabel[]>([]);
+    const [labelsPending, setLabelsPending] = useState(false);
+    const [labelsError, setLabelsError] = useState<string | null>(null);
+    const [labelsMessage, setLabelsMessage] = useState<string | null>(null);
+    const [nextPageToken, setNextPageToken] = useState('');
+    const [fetchPending, setFetchPending] = useState(false);
     const [pending, setPending] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [fetchError, setFetchError] = useState<string | null>(null);
     const [actionPending, setActionPending] = useState(false);
+    const [actionConfirmOpen, setActionConfirmOpen] = useState(false);
     const [actionError, setActionError] = useState<string | null>(null);
     const [correctionMessage, setCorrectionMessage] = useState<string | null>(null);
     const [correctionError, setCorrectionError] = useState<string | null>(null);
     const [correctionPendingByID, setCorrectionPendingByID] = useState<Record<string, boolean>>({});
     const [lastActionResult, setLastActionResult] = useState<ExecuteGmailActionsResult | null>(null);
+    const [actionHistory, setActionHistory] = useState<ActionExecutionHistory[]>([]);
+    const [fetchMessage, setFetchMessage] = useState<string | null>(null);
     const [loggingMessage, setLoggingMessage] = useState<string | null>(null);
-    const [lastClassifiedAt, setLastClassifiedAt] = useState<string | null>(
-        new Date().toISOString(),
-    );
+    const [selectedMessageID, setSelectedMessageID] = useState<string | null>(null);
+    const [selectedMessageDetail, setSelectedMessageDetail] = useState<GmailMessageDetail | null>(null);
+    const [messageDetailPending, setMessageDetailPending] = useState(false);
+    const [messageDetailError, setMessageDetailError] = useState<string | null>(null);
+    const [lastFetchedAt, setLastFetchedAt] = useState<string | null>(null);
+    const [lastClassifiedAt, setLastClassifiedAt] = useState<string | null>(null);
 
     const messageByID = useMemo(() => {
         return new Map(messages.map((message) => [message.id, message]));
@@ -260,6 +358,10 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
             message: messageByID.get(result.messageID),
         }));
     }, [messageByID, results]);
+
+    const resultByMessageID = useMemo(() => {
+        return new Map(results.map((result) => [result.messageID, result]));
+    }, [results]);
 
     const filteredRows = useMemo(() => {
         if (filter === 'all') {
@@ -284,7 +386,7 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
     }, [rows]);
 
     const approvalCandidateCount = useMemo(() => {
-        return rows.filter((row) => row.result.reviewLevel !== 'auto_apply').length;
+        return rows.filter((row) => row.result.reviewLevel !== 'hold').length;
     }, [rows]);
 
     const selectedApprovalCount = useMemo(() => {
@@ -301,8 +403,13 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
             }));
     }, [correctedCategories, rows, selectedForApproval]);
 
+    const selectedDeleteCount = useMemo(() => {
+        return selectedDecisions.filter((item) => item.category === 'junk').length;
+    }, [selectedDecisions]);
+
     function resetApprovalSelection() {
         setSelectedForApproval({});
+        setActionConfirmOpen(false);
     }
 
     function resetCorrections() {
@@ -310,6 +417,13 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
         setCorrectionMessage(null);
         setCorrectionError(null);
         setCorrectionPendingByID({});
+    }
+
+    function clearMessageDetail() {
+        setSelectedMessageID(null);
+        setSelectedMessageDetail(null);
+        setMessageDetailError(null);
+        setMessageDetailPending(false);
     }
 
     async function persistClassificationLogs(
@@ -331,25 +445,155 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
         setLoggingMessage(result.message);
     }
 
+    function ensureSelectableLabelIDs(nextLabels: GmailLabel[], previousSelected: string[]): string[] {
+        const availableSet = new Set(nextLabels.map((label) => label.id));
+        const filtered = previousSelected.filter((id) => availableSet.has(id));
+        if (filtered.length > 0) {
+            return filtered;
+        }
+        if (availableSet.has(defaultLabelID)) {
+            return [defaultLabelID];
+        }
+        if (nextLabels.length > 0) {
+            return [nextLabels[0].id];
+        }
+        return [];
+    }
+
+    async function handleLoadLabels() {
+        if (!status.gmailConnected) {
+            setLabelsError('Gmail 接続未確認のためラベル一覧を取得できません。');
+            return;
+        }
+
+        setLabelsPending(true);
+        setLabelsError(null);
+        setLabelsMessage(null);
+
+        try {
+            const response = await listGmailLabels();
+            setAvailableLabels(response.labels);
+            setSelectedLabelIDs((previous) => ensureSelectableLabelIDs(response.labels, previous));
+            if (response.labels.length === 0) {
+                setLabelsMessage('取得可能なラベルが見つかりませんでした。');
+            } else {
+                const refreshedText = response.tokenRefreshed
+                    ? ' 実行前に Google トークンを更新しました。'
+                    : '';
+                setLabelsMessage(`ラベル候補 ${response.labels.length} 件を同期しました。${refreshedText}`);
+            }
+        } catch (cause) {
+            setLabelsError(extractErrorMessage(cause, 'Gmail ラベル一覧の取得に失敗しました。'));
+        } finally {
+            setLabelsPending(false);
+        }
+    }
+
+    useEffect(() => {
+        if (!status.gmailConnected) {
+            setAvailableLabels([]);
+            setSelectedLabelIDs([]);
+            setLabelsError(null);
+            setLabelsMessage(null);
+            return;
+        }
+
+        void handleLoadLabels();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [status.gmailConnected]);
+
+    function handleLabelSelectionChange(event: React.ChangeEvent<HTMLSelectElement>) {
+        const next = Array.from(event.target.selectedOptions).map((option) => option.value);
+        setSelectedLabelIDs(next);
+    }
+
+    async function handleFetchMessages(pageToken = '') {
+        if (!status.gmailConnected) {
+            setFetchError('Gmail 接続未確認のため実メール取得できません。Settings で接続確認を行ってください。');
+            return;
+        }
+
+        const normalizedCount = normalizeFetchCount(Number(fetchCountInput));
+        setFetchCountInput(String(normalizedCount));
+        const labelIDs = selectedLabelIDs;
+
+        setFetchPending(true);
+        setFetchError(null);
+        setFetchMessage(null);
+        setError(null);
+
+        try {
+            const response = await fetchClassificationMessages({
+                query: fetchQuery.trim(),
+                maxResults: normalizedCount,
+                labelIDs,
+                pageToken,
+            });
+
+            setMessages(response.messages);
+            setResults([]);
+            setNextPageToken(response.nextPageToken);
+            setLastFetchedAt(new Date().toISOString());
+            setLastClassifiedAt(null);
+            setActionError(null);
+            setLastActionResult(null);
+            setLoggingMessage(null);
+            resetApprovalSelection();
+            resetCorrections();
+            clearMessageDetail();
+
+            if (response.messages.length === 0) {
+                setFetchMessage('指定条件に一致するメールはありませんでした。条件を変更して再取得してください。');
+            } else {
+                const queryText = fetchQuery.trim() || '指定なし';
+                const labelText = labelIDs.length > 0 ? labelIDs.join(', ') : '指定なし';
+                const pageText = response.nextPageToken ? ' 次ページがあります。' : ' 最終ページです。';
+                const refreshedText = response.tokenRefreshed
+                    ? ' 実行前に Google トークンを更新しました。'
+                    : '';
+                setFetchMessage(
+                    `実メール ${response.messages.length} 件を取得しました (query: ${queryText} / labels: ${labelText})。${pageText}${refreshedText}`,
+                );
+            }
+        } catch (cause) {
+            setFetchError(extractErrorMessage(cause, '実メール取得に失敗しました。'));
+        } finally {
+            setFetchPending(false);
+        }
+    }
+
     async function handleGenerateSample() {
-        const generated = buildSampleMessages(sampleMessageCount);
+        const generated = buildSampleMessages(defaultFetchCount);
         const nextResults = buildMockResults(generated);
         setMessages(generated);
         setResults(nextResults);
+        setFetchQuery('');
+        setSelectedLabelIDs([defaultLabelID]);
+        setFetchCountInput(String(defaultFetchCount));
+        setNextPageToken('');
+        setFetchMessage('開発補助のサンプル 50 件を読み込みました。');
+        setFetchError(null);
         setError(null);
         setActionError(null);
         setLastActionResult(null);
+        setLastFetchedAt(new Date().toISOString());
         setLastClassifiedAt(new Date().toISOString());
         resetApprovalSelection();
         resetCorrections();
+        clearMessageDetail();
         try {
             await persistClassificationLogs(generated, nextResults);
         } catch (cause) {
-            setError(cause instanceof Error ? cause.message : '分類ログ保存に失敗しました。');
+            setError(extractErrorMessage(cause, '分類ログ保存に失敗しました。'));
         }
     }
 
     async function handleShowMockResults() {
+        if (messages.length === 0) {
+            setError('モック分類の対象メールがありません。先に実メール取得またはサンプル生成を実行してください。');
+            return;
+        }
+
         const nextResults = buildMockResults(messages);
         setResults(nextResults);
         setError(null);
@@ -361,11 +605,16 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
         try {
             await persistClassificationLogs(messages, nextResults);
         } catch (cause) {
-            setError(cause instanceof Error ? cause.message : '分類ログ保存に失敗しました。');
+            setError(extractErrorMessage(cause, '分類ログ保存に失敗しました。'));
         }
     }
 
     async function handleClassifyWithClaude() {
+        if (messages.length === 0) {
+            setError('分類対象の実メールがありません。先に実メール取得を実行してください。');
+            return;
+        }
+
         setPending(true);
         setError(null);
 
@@ -387,11 +636,7 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
             resetCorrections();
             await persistClassificationLogs(messages, response.results);
         } catch (cause) {
-            const message =
-                cause instanceof Error
-                    ? cause.message
-                    : 'Claude 分類に失敗しました。';
-            setError(message);
+            setError(extractErrorMessage(cause, 'Claude 分類に失敗しました。'));
         } finally {
             setPending(false);
         }
@@ -402,6 +647,43 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
             ...previous,
             [messageID]: !previous[messageID],
         }));
+    }
+
+    function handleSelectAllExecutableRows() {
+        const next: Record<string, boolean> = {};
+        for (const row of rows) {
+            if (row.result.reviewLevel === 'hold') {
+                continue;
+            }
+            next[row.result.messageID] = true;
+        }
+        setSelectedForApproval(next);
+    }
+
+    async function handleOpenMessageDetail(messageID: string) {
+        const summary = messageByID.get(messageID);
+        if (!summary) {
+            return;
+        }
+
+        setSelectedMessageID(messageID);
+        setMessageDetailError(null);
+        setSelectedMessageDetail(null);
+
+        if (messageID.startsWith('sample-')) {
+            setSelectedMessageDetail(buildSampleMessageDetail(summary));
+            return;
+        }
+
+        setMessageDetailPending(true);
+        try {
+            const detail = await fetchGmailMessageDetail(messageID);
+            setSelectedMessageDetail(detail);
+        } catch (cause) {
+            setMessageDetailError(extractErrorMessage(cause, 'メール詳細の取得に失敗しました。'));
+        } finally {
+            setMessageDetailPending(false);
+        }
     }
 
     async function handleCategoryCorrection(row: ClassifiedRow, nextCategory: ClassificationCategory) {
@@ -449,7 +731,7 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
                 `${messageID} の修正を保存しました。3 回以上の同一傾向で Blocklist 提案に表示されます。`,
             );
         } catch (cause) {
-            setCorrectionError(cause instanceof Error ? cause.message : '修正履歴の保存に失敗しました。');
+            setCorrectionError(extractErrorMessage(cause, '修正履歴の保存に失敗しました。'));
         } finally {
             setCorrectionPendingByID((previous) => ({
                 ...previous,
@@ -463,19 +745,18 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
             setActionError('実行対象を選択してください。');
             return;
         }
+        setActionError(null);
+        setActionConfirmOpen(true);
+    }
 
-        const deleteCount = selectedDecisions.filter((item) => item.category === 'junk').length;
-        const confirmed = window.confirm(
-            [
-                `選択した ${selectedDecisions.length} 件を Gmail に反映します。`,
-                deleteCount > 0 ? `このうち ${deleteCount} 件は削除されます。` : '削除対象は含まれていません。',
-                '実行しますか？',
-            ].join('\n'),
-        );
-        if (!confirmed) {
+    async function handleConfirmExecuteSelectedActions() {
+        if (selectedDecisions.length === 0) {
+            setActionError('実行対象を選択してください。');
+            setActionConfirmOpen(false);
             return;
         }
 
+        setActionConfirmOpen(false);
         setActionPending(true);
         setActionError(null);
 
@@ -497,17 +778,21 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
                     })),
             });
             setLastActionResult(result);
+            setActionHistory((previous) => [
+                {
+                    at: new Date().toISOString(),
+                    selectedCount: selectedDecisions.length,
+                    result,
+                },
+                ...previous,
+            ]);
             resetApprovalSelection();
 
             if (!result.success) {
                 setActionError(result.message);
             }
         } catch (cause) {
-            const message =
-                cause instanceof Error
-                    ? cause.message
-                    : 'Gmail アクション実行に失敗しました。';
-            setActionError(message);
+            setActionError(extractErrorMessage(cause, 'Gmail アクション実行に失敗しました。'));
         } finally {
             setActionPending(false);
         }
@@ -516,11 +801,11 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
     return (
         <div className="classify-page">
             <section className="classify-hero">
-                <p className="classify-eyebrow">MAIRU-009 / #9</p>
-                <h1>分類確認</h1>
+                <p className="classify-eyebrow">MAIRU-024 / #48</p>
+                <h1>実メール分類フロー</h1>
                 <p className="classify-lead">
-                    50 件の分類結果を信頼度で振り分け、承認対象を判断するための画面です。
-                    自動実行候補と要確認候補を分けて確認できます。
+                    Classify 画面内で「実メール取得 → Claude 分類 → 承認選択 → Gmail 反映」までを完結させます。
+                    query・件数・ラベル条件を指定し、反映結果と失敗理由をこの画面で追跡できます。
                 </p>
                 <div className="classify-hero-status">
                     <span className={`hero-chip ${status.claudeConfigured ? 'ready' : 'pending'}`}>
@@ -532,8 +817,96 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
                 </div>
             </section>
 
-            <section className="classify-controls" aria-label="分類実行コントロール">
-                <div className="classify-control-row">
+            <section className="classify-controls" aria-label="実メール取得と分類実行">
+                <div className="classify-control-row classify-fetch-row">
+                    <label className="classify-field" htmlFor="fetch-query">
+                        <span>Gmail クエリ (任意)</span>
+                        <input
+                            id="fetch-query"
+                            type="text"
+                            value={fetchQuery}
+                            onChange={(event) => {
+                                setFetchQuery(event.target.value);
+                            }}
+                            placeholder="例: newer_than:7d -category:promotions"
+                        />
+                    </label>
+                    <label className="classify-field classify-field-sm" htmlFor="fetch-count">
+                        <span>取得件数 (1-50)</span>
+                        <input
+                            id="fetch-count"
+                            type="number"
+                            min={1}
+                            max={maxFetchCount}
+                            value={fetchCountInput}
+                            onChange={(event) => {
+                                const raw = event.target.value;
+                                if (raw === '' || /^[0-9]+$/.test(raw)) {
+                                    setFetchCountInput(raw);
+                                }
+                            }}
+                            onBlur={() => {
+                                setFetchCountInput((previous) => normalizeFetchCountInput(previous));
+                            }}
+                        />
+                    </label>
+                    <label className="classify-field" htmlFor="fetch-labels">
+                        <span>対象ラベル (自動取得 / 複数選択)</span>
+                        <select
+                            id="fetch-labels"
+                            className="classify-label-select"
+                            multiple
+                            size={6}
+                            value={selectedLabelIDs}
+                            onChange={handleLabelSelectionChange}
+                            disabled={labelsPending || !status.gmailConnected || availableLabels.length === 0}
+                        >
+                            {availableLabels.map((label) => (
+                                <option key={label.id} value={label.id}>
+                                    {label.name} ({label.id}){label.type ? ` / ${label.type}` : ''}
+                                </option>
+                            ))}
+                        </select>
+                    </label>
+                    <button
+                        type="button"
+                        className="classify-secondary-button"
+                        onClick={() => {
+                            void handleLoadLabels();
+                        }}
+                        disabled={labelsPending || fetchPending || pending || !status.gmailConnected}
+                    >
+                        {labelsPending ? 'ラベル同期中...' : 'ラベル候補を更新'}
+                    </button>
+                    <button
+                        type="button"
+                        className="classify-primary-button"
+                        onClick={() => {
+                            void handleFetchMessages();
+                        }}
+                        disabled={fetchPending || pending || actionPending || !status.gmailConnected}
+                    >
+                        {fetchPending ? '実メール取得中...' : '実メールを取得'}
+                    </button>
+                    <button
+                        type="button"
+                        className="classify-secondary-button"
+                        onClick={() => {
+                            void handleFetchMessages(nextPageToken);
+                        }}
+                        disabled={
+                            fetchPending ||
+                            pending ||
+                            actionPending ||
+                            !status.gmailConnected ||
+                            nextPageToken === ''
+                        }
+                    >
+                        次ページを取得
+                    </button>
+                </div>
+
+                <div className="classify-control-row classify-model-row">
                     <label className="classify-field" htmlFor="classify-model">
                         <span>Claude モデル (任意)</span>
                         <input
@@ -548,45 +921,221 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
                     </label>
                     <button
                         type="button"
-                        className="classify-secondary-button"
-                        onClick={() => {
-                            void handleGenerateSample();
-                        }}
-                        disabled={pending}
-                    >
-                        50 件サンプルを再生成
-                    </button>
-                    <button
-                        type="button"
-                        className="classify-secondary-button"
-                        onClick={() => {
-                            void handleShowMockResults();
-                        }}
-                        disabled={pending}
-                    >
-                        モック分類を表示
-                    </button>
-                    <button
-                        type="button"
                         className="classify-primary-button"
                         onClick={() => {
                             void handleClassifyWithClaude();
                         }}
-                        disabled={pending || !status.claudeConfigured}
+                        disabled={pending || fetchPending || !status.claudeConfigured || messages.length === 0}
                     >
-                        {pending ? 'Claude 分類中...' : 'Claude で分類'}
+                        {pending ? 'Claude 分類中...' : '取得メールを Claude で分類'}
                     </button>
                 </div>
+
                 <p className="classify-inline-note">
-                    対象件数: {messages.length} 件 / 最終更新: {formatClassifiedAt(lastClassifiedAt)}
+                    取得件数: {messages.length} 件 / 最終取得: {formatDateTime(lastFetchedAt)} / 最終分類: {formatDateTime(lastClassifiedAt)}
                 </p>
-                {!status.claudeConfigured ? (
+                {!status.gmailConnected ? (
                     <p className="classify-inline-note">
-                        Claude API キー未設定のため、実 API 実行は無効化しています。Settings から設定できます。
+                        Gmail 接続未確認のため実メール取得を無効化しています。Settings で接続確認を先に行ってください。
                     </p>
                 ) : null}
+                {!status.claudeConfigured ? (
+                    <p className="classify-inline-note">
+                        Claude API キー未設定のため、分類実行を無効化しています。Settings から設定できます。
+                    </p>
+                ) : null}
+                <p className="classify-inline-note">
+                    選択ラベル: {selectedLabelIDs.length > 0 ? selectedLabelIDs.join(', ') : '未選択'}
+                </p>
+                {labelsMessage ? <p className="classify-inline-note">{labelsMessage}</p> : null}
+                {labelsError ? <p className="classify-error-note">{labelsError}</p> : null}
+                {fetchMessage ? <p className="classify-inline-note">{fetchMessage}</p> : null}
+                {fetchError ? <p className="classify-error-note">{fetchError}</p> : null}
                 {error ? <p className="classify-error-note">{error}</p> : null}
                 {loggingMessage ? <p className="classify-inline-note">{loggingMessage}</p> : null}
+
+                <details className="classify-devtools">
+                    <summary>開発補助: サンプル / モック導線</summary>
+                    <div className="classify-devtools-actions">
+                        <button
+                            type="button"
+                            className="classify-secondary-button"
+                            onClick={() => {
+                                void handleGenerateSample();
+                            }}
+                            disabled={pending || fetchPending}
+                        >
+                            50 件サンプルを生成
+                        </button>
+                        <button
+                            type="button"
+                            className="classify-secondary-button"
+                            onClick={() => {
+                                void handleShowMockResults();
+                            }}
+                            disabled={pending || fetchPending || messages.length === 0}
+                        >
+                            モック分類を表示
+                        </button>
+                    </div>
+                </details>
+            </section>
+
+            <section className="classify-fetched" aria-label="取得メール一覧">
+                <div className="classify-results-header">
+                    <div>
+                        <h2>取得メール一覧</h2>
+                        <p>
+                            取得済み {messages.length} 件。Claude 分類後は分類状態もここで確認できます。
+                        </p>
+                    </div>
+                </div>
+                <div className="classify-table-wrap">
+                    <table>
+                        <thead>
+                            <tr>
+                                <th scope="col">未読</th>
+                                <th scope="col">差出人 / 件名</th>
+                                <th scope="col">スニペット</th>
+                                <th scope="col">分類状態</th>
+                                <th scope="col">メッセージID</th>
+                                <th scope="col">詳細</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {messages.map((message) => {
+                                const result = resultByMessageID.get(message.id);
+                                return (
+                                    <tr key={message.id}>
+                                        <td>
+                                            <p className={`unread-chip ${message.unread ? 'unread' : 'read'}`}>
+                                                {message.unread ? '未読' : '既読'}
+                                            </p>
+                                        </td>
+                                        <td>
+                                            <p className="result-primary">{message.from || '不明な差出人'}</p>
+                                            <p className="result-secondary">{message.subject || '(件名なし)'}</p>
+                                        </td>
+                                        <td className="reason-text">{message.snippet || '-'}</td>
+                                        <td>
+                                            {result ? (
+                                                <>
+                                                    <p className={`category-chip category-${result.category}`}>
+                                                        {categoryLabel(result.category)}
+                                                    </p>
+                                                    <p className={`review-chip review-${result.reviewLevel}`}>
+                                                        {reviewLabel(result.reviewLevel)}
+                                                    </p>
+                                                </>
+                                            ) : (
+                                                <p className="result-secondary">未分類</p>
+                                            )}
+                                        </td>
+                                        <td>
+                                            <p className="result-secondary classify-id">{message.id}</p>
+                                        </td>
+                                        <td>
+                                            <button
+                                                type="button"
+                                                className="classify-secondary-button"
+                                                onClick={() => {
+                                                    void handleOpenMessageDetail(message.id);
+                                                }}
+                                                disabled={messageDetailPending && selectedMessageID === message.id}
+                                            >
+                                                {messageDetailPending && selectedMessageID === message.id
+                                                    ? '読込中...'
+                                                    : '詳細を開く'}
+                                            </button>
+                                        </td>
+                                    </tr>
+                                );
+                            })}
+                        </tbody>
+                    </table>
+                    {messages.length === 0 ? (
+                        <p className="classify-empty">実メールが未取得です。上部の取得条件を指定して読み込んでください。</p>
+                    ) : null}
+                </div>
+                {selectedMessageID ? (
+                    <div className="classify-message-detail">
+                        <div className="classify-message-detail-header">
+                            <h3>メール詳細</h3>
+                            <button
+                                type="button"
+                                className="classify-secondary-button"
+                                onClick={clearMessageDetail}
+                            >
+                                閉じる
+                            </button>
+                        </div>
+                        {messageDetailPending ? (
+                            <p className="classify-inline-note">メール詳細を取得しています...</p>
+                        ) : messageDetailError ? (
+                            <p className="classify-error-note">{messageDetailError}</p>
+                        ) : selectedMessageDetail ? (
+                            <>
+                                <dl className="classify-message-meta">
+                                    <div>
+                                        <dt>件名</dt>
+                                        <dd>{selectedMessageDetail.subject || '(件名なし)'}</dd>
+                                    </div>
+                                    <div>
+                                        <dt>差出人</dt>
+                                        <dd>{selectedMessageDetail.from || '不明'}</dd>
+                                    </div>
+                                    <div>
+                                        <dt>宛先</dt>
+                                        <dd>{selectedMessageDetail.to || '-'}</dd>
+                                    </div>
+                                    <div>
+                                        <dt>受信日時</dt>
+                                        <dd>{selectedMessageDetail.date || '-'}</dd>
+                                    </div>
+                                    <div>
+                                        <dt>Thread ID</dt>
+                                        <dd className="classify-id">{selectedMessageDetail.threadID || '-'}</dd>
+                                    </div>
+                                    <div>
+                                        <dt>Message ID</dt>
+                                        <dd className="classify-id">{selectedMessageDetail.id}</dd>
+                                    </div>
+                                </dl>
+                                <p className="classify-inline-note">
+                                    ラベル: {selectedMessageDetail.labelIDs.length > 0 ? selectedMessageDetail.labelIDs.join(', ') : '-'}
+                                </p>
+                                <p className="classify-inline-note">
+                                    スニペット: {selectedMessageDetail.snippet || '-'}
+                                </p>
+                                <details open>
+                                    <summary>本文テキスト</summary>
+                                    <pre className="classify-message-body">
+                                        {selectedMessageDetail.bodyText || '(本文テキストは取得できませんでした)'}
+                                    </pre>
+                                </details>
+                                {selectedMessageDetail.bodyHTML ? (
+                                    <details>
+                                        <summary>本文 HTML ソース</summary>
+                                        <pre className="classify-message-body">{selectedMessageDetail.bodyHTML}</pre>
+                                    </details>
+                                ) : null}
+                                {selectedMessageDetail.headers.length > 0 ? (
+                                    <details>
+                                        <summary>ヘッダ一覧</summary>
+                                        <ul className="classify-header-list">
+                                            {selectedMessageDetail.headers.map((header, index) => (
+                                                <li key={`${header.name}-${index}`}>
+                                                    <span className="header-name">{header.name}:</span>{' '}
+                                                    <span className="header-value">{header.value}</span>
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    </details>
+                                ) : null}
+                            </>
+                        ) : null}
+                    </div>
+                ) : null}
             </section>
 
             <section className="classify-summary" aria-label="信頼度分岐サマリー">
@@ -614,29 +1163,81 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
                         <h2>承認済みアクション実行</h2>
                         <p>
                             選択中 {selectedDecisions.length} 件を Gmail 側へ反映します。
-                            削除を含む場合は確認ダイアログを表示します。
+                            実行前に画面内の確認ステップを表示します。
                         </p>
                     </div>
-                    <button
-                        type="button"
-                        className="classify-primary-button"
-                        onClick={() => {
-                            void handleExecuteSelectedActions();
-                        }}
-                        disabled={
-                            actionPending ||
-                            pending ||
-                            !status.gmailConnected ||
-                            selectedDecisions.length === 0
-                        }
-                    >
-                        {actionPending ? 'Gmail 反映中...' : '選択した承認を Gmail に適用'}
-                    </button>
+                    <div className="classify-actions-buttons">
+                        <button
+                            type="button"
+                            className="classify-secondary-button"
+                            onClick={handleSelectAllExecutableRows}
+                            disabled={rows.length === 0 || pending || actionPending}
+                        >
+                            実行候補を全選択
+                        </button>
+                        <button
+                            type="button"
+                            className="classify-secondary-button"
+                            onClick={resetApprovalSelection}
+                            disabled={selectedDecisions.length === 0 || pending || actionPending}
+                        >
+                            選択解除
+                        </button>
+                        <button
+                            type="button"
+                            className="classify-primary-button"
+                            onClick={() => {
+                                void handleExecuteSelectedActions();
+                            }}
+                            disabled={
+                                actionPending ||
+                                actionConfirmOpen ||
+                                pending ||
+                                fetchPending ||
+                                !status.gmailConnected ||
+                                selectedDecisions.length === 0
+                            }
+                        >
+                            {actionPending ? 'Gmail 反映中...' : '選択した承認を Gmail に適用'}
+                        </button>
+                    </div>
                 </div>
                 {!status.gmailConnected ? (
                     <p className="classify-inline-note">
                         Gmail 接続未確認のため実行できません。Settings で接続確認を先に行ってください。
                     </p>
+                ) : null}
+                {actionConfirmOpen ? (
+                    <div className="classify-confirm-panel">
+                        <p>
+                            選択した {selectedDecisions.length} 件を Gmail に反映します。
+                            {selectedDeleteCount > 0
+                                ? ` このうち ${selectedDeleteCount} 件は削除されます。`
+                                : ' 削除対象は含まれていません。'}
+                        </p>
+                        <div className="classify-actions-buttons">
+                            <button
+                                type="button"
+                                className="classify-secondary-button"
+                                onClick={() => {
+                                    setActionConfirmOpen(false);
+                                }}
+                                disabled={actionPending}
+                            >
+                                キャンセル
+                            </button>
+                            <button
+                                type="button"
+                                className="classify-primary-button"
+                                onClick={() => {
+                                    void handleConfirmExecuteSelectedActions();
+                                }}
+                                disabled={actionPending}
+                            >
+                                実行する
+                            </button>
+                        </div>
+                    </div>
                 ) : null}
                 {lastActionResult ? (
                     <div className="classify-action-result">
@@ -645,12 +1246,20 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
                         </p>
                         <dl className="classify-action-stats">
                             <div>
+                                <dt>処理対象</dt>
+                                <dd>{lastActionResult.processedCount} 件</dd>
+                            </div>
+                            <div>
                                 <dt>成功</dt>
                                 <dd>{lastActionResult.successCount} 件</dd>
                             </div>
                             <div>
                                 <dt>失敗</dt>
                                 <dd>{lastActionResult.failureCount} 件</dd>
+                            </div>
+                            <div>
+                                <dt>スキップ</dt>
+                                <dd>{lastActionResult.skippedCount} 件</dd>
                             </div>
                             <div>
                                 <dt>削除</dt>
@@ -691,6 +1300,19 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
                     </div>
                 ) : null}
                 {actionError ? <p className="classify-error-note">{actionError}</p> : null}
+                {actionHistory.length > 0 ? (
+                    <div className="classify-history">
+                        <h3>実行履歴 (最新 5 件)</h3>
+                        <ul>
+                            {actionHistory.slice(0, 5).map((item, index) => (
+                                <li key={`${item.at}-${index}`}>
+                                    {formatDateTime(item.at)} / 選択 {item.selectedCount} 件 / 成功 {item.result.successCount} /
+                                    失敗 {item.result.failureCount} / スキップ {item.result.skippedCount}
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                ) : null}
             </section>
 
             <section className="classify-results" aria-label="分類結果一覧">
@@ -698,7 +1320,7 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
                     <div>
                         <h2>分類結果一覧</h2>
                         <p>
-                            承認候補 {approvalCandidateCount} 件中 {selectedApprovalCount} 件を選択中
+                            実行候補 {approvalCandidateCount} 件中 {selectedApprovalCount} 件を選択中
                         </p>
                     </div>
                     <div className="classify-filter-group" role="group" aria-label="レビュー状態で絞り込み">
@@ -746,7 +1368,7 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
                                     100,
                                     Math.max(0, Math.round(numericConfidence * 100)),
                                 );
-                                const approvalEnabled = row.result.reviewLevel !== 'auto_apply';
+                                const approvalEnabled = row.result.reviewLevel !== 'hold';
                                 const resolvedCategory =
                                     correctedCategories[row.result.messageID] ?? row.result.category;
                                 return (
@@ -824,7 +1446,11 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
                             })}
                         </tbody>
                     </table>
-                    {filteredRows.length === 0 ? (
+                    {messages.length === 0 ? (
+                        <p className="classify-empty">実メールが未取得です。上部の取得条件を指定して読み込んでください。</p>
+                    ) : filteredRows.length === 0 && results.length === 0 ? (
+                        <p className="classify-empty">分類結果がありません。Claude 分類を実行してください。</p>
+                    ) : filteredRows.length === 0 ? (
                         <p className="classify-empty">該当する分類結果はありません。</p>
                     ) : null}
                 </div>

--- a/frontend/src/pages/Classify/ClassifyPage.tsx
+++ b/frontend/src/pages/Classify/ClassifyPage.tsx
@@ -648,14 +648,22 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
                 return;
             }
 
+            const includesSampleMessages =
+                messages.some((message) => message.id.startsWith('sample-')) ||
+                response.results.some((result) => result.messageID.startsWith('sample-'));
+
             setResults(response.results);
-            setClassificationDataMode('live');
+            setClassificationDataMode(includesSampleMessages ? 'sample' : 'live');
             setLastClassifiedAt(new Date().toISOString());
             setActionError(null);
             setLastActionResult(null);
             resetApprovalSelection();
             resetCorrections();
-            await persistClassificationLogs(messages, response.results);
+            if (includesSampleMessages) {
+                setLoggingMessage('サンプル結果のため分類ログ保存はスキップしました。');
+            } else {
+                await persistClassificationLogs(messages, response.results);
+            }
         } catch (cause) {
             setError(extractErrorMessage(cause, 'Claude 分類に失敗しました。'));
         } finally {

--- a/frontend/src/pages/Classify/ClassifyPage.tsx
+++ b/frontend/src/pages/Classify/ClassifyPage.tsx
@@ -1,6 +1,6 @@
 import './ClassifyPage.css';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import {
     classifyEmails,
@@ -36,6 +36,8 @@ type ActionExecutionHistory = {
     selectedCount: number;
     result: ExecuteGmailActionsResult;
 };
+
+type ClassificationDataMode = 'live' | 'sample' | 'mock';
 
 const maxFetchCount = 50;
 const defaultFetchCount = 50;
@@ -345,8 +347,11 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
     const [selectedMessageDetail, setSelectedMessageDetail] = useState<GmailMessageDetail | null>(null);
     const [messageDetailPending, setMessageDetailPending] = useState(false);
     const [messageDetailError, setMessageDetailError] = useState<string | null>(null);
+    const [classificationDataMode, setClassificationDataMode] = useState<ClassificationDataMode>('live');
     const [lastFetchedAt, setLastFetchedAt] = useState<string | null>(null);
     const [lastClassifiedAt, setLastClassifiedAt] = useState<string | null>(null);
+    const messageDetailRequestIDRef = useRef(0);
+    const isLiveDataMode = classificationDataMode === 'live';
 
     const messageByID = useMemo(() => {
         return new Map(messages.map((message) => [message.id, message]));
@@ -420,6 +425,7 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
     }
 
     function clearMessageDetail() {
+        messageDetailRequestIDRef.current += 1;
         setSelectedMessageID(null);
         setSelectedMessageDetail(null);
         setMessageDetailError(null);
@@ -474,6 +480,7 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
             const response = await listGmailLabels();
             setAvailableLabels(response.labels);
             setSelectedLabelIDs((previous) => ensureSelectableLabelIDs(response.labels, previous));
+            setNextPageToken('');
             if (response.labels.length === 0) {
                 setLabelsMessage('取得可能なラベルが見つかりませんでした。');
             } else {
@@ -505,6 +512,24 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
     function handleLabelSelectionChange(event: React.ChangeEvent<HTMLSelectElement>) {
         const next = Array.from(event.target.selectedOptions).map((option) => option.value);
         setSelectedLabelIDs(next);
+        setNextPageToken('');
+    }
+
+    function handleQueryChange(event: React.ChangeEvent<HTMLInputElement>) {
+        setFetchQuery(event.target.value);
+        setNextPageToken('');
+    }
+
+    function handleCountChange(event: React.ChangeEvent<HTMLInputElement>) {
+        const raw = event.target.value;
+        if (raw === '' || /^[0-9]+$/.test(raw)) {
+            setFetchCountInput(raw);
+            setNextPageToken('');
+        }
+    }
+
+    function handleCountBlur() {
+        setFetchCountInput((previous) => normalizeFetchCountInput(previous));
     }
 
     async function handleFetchMessages(pageToken = '') {
@@ -532,6 +557,7 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
 
             setMessages(response.messages);
             setResults([]);
+            setClassificationDataMode('live');
             setNextPageToken(response.nextPageToken);
             setLastFetchedAt(new Date().toISOString());
             setLastClassifiedAt(null);
@@ -567,6 +593,7 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
         const nextResults = buildMockResults(generated);
         setMessages(generated);
         setResults(nextResults);
+        setClassificationDataMode('sample');
         setFetchQuery('');
         setSelectedLabelIDs([defaultLabelID]);
         setFetchCountInput(String(defaultFetchCount));
@@ -581,11 +608,7 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
         resetApprovalSelection();
         resetCorrections();
         clearMessageDetail();
-        try {
-            await persistClassificationLogs(generated, nextResults);
-        } catch (cause) {
-            setError(extractErrorMessage(cause, '分類ログ保存に失敗しました。'));
-        }
+        setLoggingMessage('開発補助のサンプル結果のため分類ログ保存はスキップしました。');
     }
 
     async function handleShowMockResults() {
@@ -596,17 +619,14 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
 
         const nextResults = buildMockResults(messages);
         setResults(nextResults);
+        setClassificationDataMode('mock');
         setError(null);
         setActionError(null);
         setLastActionResult(null);
         setLastClassifiedAt(new Date().toISOString());
         resetApprovalSelection();
         resetCorrections();
-        try {
-            await persistClassificationLogs(messages, nextResults);
-        } catch (cause) {
-            setError(extractErrorMessage(cause, '分類ログ保存に失敗しました。'));
-        }
+        setLoggingMessage('開発補助のモック結果のため分類ログ保存はスキップしました。');
     }
 
     async function handleClassifyWithClaude() {
@@ -629,6 +649,7 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
             }
 
             setResults(response.results);
+            setClassificationDataMode('live');
             setLastClassifiedAt(new Date().toISOString());
             setActionError(null);
             setLastActionResult(null);
@@ -666,11 +687,14 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
             return;
         }
 
+        const requestID = messageDetailRequestIDRef.current + 1;
+        messageDetailRequestIDRef.current = requestID;
         setSelectedMessageID(messageID);
         setMessageDetailError(null);
         setSelectedMessageDetail(null);
 
         if (messageID.startsWith('sample-')) {
+            setMessageDetailPending(false);
             setSelectedMessageDetail(buildSampleMessageDetail(summary));
             return;
         }
@@ -678,15 +702,29 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
         setMessageDetailPending(true);
         try {
             const detail = await fetchGmailMessageDetail(messageID);
+            if (messageDetailRequestIDRef.current !== requestID) {
+                return;
+            }
             setSelectedMessageDetail(detail);
         } catch (cause) {
+            if (messageDetailRequestIDRef.current !== requestID) {
+                return;
+            }
             setMessageDetailError(extractErrorMessage(cause, 'メール詳細の取得に失敗しました。'));
         } finally {
-            setMessageDetailPending(false);
+            if (messageDetailRequestIDRef.current === requestID) {
+                setMessageDetailPending(false);
+            }
         }
     }
 
     async function handleCategoryCorrection(row: ClassifiedRow, nextCategory: ClassificationCategory) {
+        if (!isLiveDataMode) {
+            setCorrectionError('サンプル/モック結果では分類修正を保存できません。');
+            setCorrectionMessage(null);
+            return;
+        }
+
         const messageID = row.result.messageID;
         setCorrectedCategories((previous) => ({
             ...previous,
@@ -741,6 +779,10 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
     }
 
     async function handleExecuteSelectedActions() {
+        if (!isLiveDataMode) {
+            setActionError('サンプル/モック結果は Gmail に適用できません。実メールを取得して Claude 分類を実行してください。');
+            return;
+        }
         if (selectedDecisions.length === 0) {
             setActionError('実行対象を選択してください。');
             return;
@@ -750,6 +792,11 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
     }
 
     async function handleConfirmExecuteSelectedActions() {
+        if (!isLiveDataMode) {
+            setActionError('サンプル/モック結果は Gmail に適用できません。');
+            setActionConfirmOpen(false);
+            return;
+        }
         if (selectedDecisions.length === 0) {
             setActionError('実行対象を選択してください。');
             setActionConfirmOpen(false);
@@ -825,9 +872,7 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
                             id="fetch-query"
                             type="text"
                             value={fetchQuery}
-                            onChange={(event) => {
-                                setFetchQuery(event.target.value);
-                            }}
+                            onChange={handleQueryChange}
                             placeholder="例: newer_than:7d -category:promotions"
                         />
                     </label>
@@ -839,15 +884,8 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
                             min={1}
                             max={maxFetchCount}
                             value={fetchCountInput}
-                            onChange={(event) => {
-                                const raw = event.target.value;
-                                if (raw === '' || /^[0-9]+$/.test(raw)) {
-                                    setFetchCountInput(raw);
-                                }
-                            }}
-                            onBlur={() => {
-                                setFetchCountInput((previous) => normalizeFetchCountInput(previous));
-                            }}
+                            onChange={handleCountChange}
+                            onBlur={handleCountBlur}
                         />
                     </label>
                     <label className="classify-field" htmlFor="fetch-labels">
@@ -947,6 +985,12 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
                 <p className="classify-inline-note">
                     選択ラベル: {selectedLabelIDs.length > 0 ? selectedLabelIDs.join(', ') : '未選択'}
                 </p>
+                {!isLiveDataMode ? (
+                    <p className="classify-inline-note">
+                        現在は{classificationDataMode === 'sample' ? 'サンプル' : 'モック'}結果表示中のため、
+                        分類修正保存と Gmail 反映を無効化しています。
+                    </p>
+                ) : null}
                 {labelsMessage ? <p className="classify-inline-note">{labelsMessage}</p> : null}
                 {labelsError ? <p className="classify-error-note">{labelsError}</p> : null}
                 {fetchMessage ? <p className="classify-inline-note">{fetchMessage}</p> : null}
@@ -1041,7 +1085,7 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
                                                 onClick={() => {
                                                     void handleOpenMessageDetail(message.id);
                                                 }}
-                                                disabled={messageDetailPending && selectedMessageID === message.id}
+                                                disabled={messageDetailPending}
                                             >
                                                 {messageDetailPending && selectedMessageID === message.id
                                                     ? '読込中...'
@@ -1171,7 +1215,7 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
                             type="button"
                             className="classify-secondary-button"
                             onClick={handleSelectAllExecutableRows}
-                            disabled={rows.length === 0 || pending || actionPending}
+                            disabled={rows.length === 0 || pending || actionPending || !isLiveDataMode}
                         >
                             実行候補を全選択
                         </button>
@@ -1179,7 +1223,7 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
                             type="button"
                             className="classify-secondary-button"
                             onClick={resetApprovalSelection}
-                            disabled={selectedDecisions.length === 0 || pending || actionPending}
+                            disabled={selectedDecisions.length === 0 || pending || actionPending || !isLiveDataMode}
                         >
                             選択解除
                         </button>
@@ -1195,6 +1239,7 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
                                 pending ||
                                 fetchPending ||
                                 !status.gmailConnected ||
+                                !isLiveDataMode ||
                                 selectedDecisions.length === 0
                             }
                         >
@@ -1207,7 +1252,7 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
                         Gmail 接続未確認のため実行できません。Settings で接続確認を先に行ってください。
                     </p>
                 ) : null}
-                {actionConfirmOpen ? (
+                {actionConfirmOpen && isLiveDataMode ? (
                     <div className="classify-confirm-panel">
                         <p>
                             選択した {selectedDecisions.length} 件を Gmail に反映します。
@@ -1368,7 +1413,7 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
                                     100,
                                     Math.max(0, Math.round(numericConfidence * 100)),
                                 );
-                                const approvalEnabled = row.result.reviewLevel !== 'hold';
+                                const approvalEnabled = row.result.reviewLevel !== 'hold' && isLiveDataMode;
                                 const resolvedCategory =
                                     correctedCategories[row.result.messageID] ?? row.result.category;
                                 return (
@@ -1418,7 +1463,11 @@ export function ClassifyPage({ status }: ClassifyPageProps) {
                                                         event.target.value as ClassificationCategory,
                                                     );
                                                 }}
-                                                disabled={pending || Boolean(correctionPendingByID[row.result.messageID])}
+                                                disabled={
+                                                    pending ||
+                                                    !isLiveDataMode ||
+                                                    Boolean(correctionPendingByID[row.result.messageID])
+                                                }
                                                 aria-label={`${row.result.messageID} の分類修正`}
                                             >
                                                 {categoryOptions.map((option) => (

--- a/internal/claude/classify.go
+++ b/internal/claude/classify.go
@@ -302,7 +302,7 @@ func parseClassificationEntries(raw string) ([]classificationResultPayload, bool
 }
 
 func buildParseCandidates(raw string) []string {
-	candidates := make([]string, 0, 4)
+	candidates := make([]string, 0, 8)
 	appendCandidate := func(value string) {
 		trimmed := strings.TrimSpace(value)
 		if trimmed == "" {
@@ -315,8 +315,15 @@ func buildParseCandidates(raw string) []string {
 		}
 		candidates = append(candidates, trimmed)
 	}
+	appendSegments := func(value string) {
+		segments := extractBalancedJSONSegments(value)
+		for _, segment := range segments {
+			appendCandidate(segment)
+		}
+	}
 
 	appendCandidate(raw)
+	appendSegments(raw)
 
 	unquoted := raw
 	for i := 0; i < 2; i++ {
@@ -325,12 +332,8 @@ func buildParseCandidates(raw string) []string {
 			break
 		}
 		appendCandidate(decoded)
+		appendSegments(decoded)
 		unquoted = strings.TrimSpace(decoded)
-	}
-
-	segments := extractBalancedJSONSegments(raw)
-	for _, segment := range segments {
-		appendCandidate(segment)
 	}
 
 	return candidates

--- a/internal/claude/classify.go
+++ b/internal/claude/classify.go
@@ -259,17 +259,159 @@ func parseClassificationResults(raw string, messages []types.EmailSummary) ([]ty
 		return nil, fmt.Errorf("Claude API 応答が空です")
 	}
 
+	candidates := buildParseCandidates(trimmed)
+	var lastNormalizeErr error
+	for _, candidate := range candidates {
+		entries, ok := parseClassificationEntries(candidate)
+		if !ok {
+			continue
+		}
+
+		normalized, err := normalizeResults(entries, messages)
+		if err != nil {
+			lastNormalizeErr = err
+			continue
+		}
+		return normalized, nil
+	}
+
+	if lastNormalizeErr != nil {
+		return nil, lastNormalizeErr
+	}
+
+	return nil, fmt.Errorf("Claude API 応答を分類結果 JSON として解釈できません")
+}
+
+func parseClassificationEntries(raw string) ([]classificationResultPayload, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, false
+	}
+
 	var direct []classificationResultPayload
 	if err := json.Unmarshal([]byte(trimmed), &direct); err == nil {
-		return normalizeResults(direct, messages)
+		return direct, true
 	}
 
 	var wrapped classificationEnvelope
 	if err := json.Unmarshal([]byte(trimmed), &wrapped); err == nil {
-		return normalizeResults(wrapped.Results, messages)
+		return wrapped.Results, true
 	}
 
-	return nil, fmt.Errorf("Claude API 応答を分類結果 JSON として解釈できません")
+	return nil, false
+}
+
+func buildParseCandidates(raw string) []string {
+	candidates := make([]string, 0, 4)
+	appendCandidate := func(value string) {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			return
+		}
+		for _, existing := range candidates {
+			if existing == trimmed {
+				return
+			}
+		}
+		candidates = append(candidates, trimmed)
+	}
+
+	appendCandidate(raw)
+
+	unquoted := raw
+	for i := 0; i < 2; i++ {
+		var decoded string
+		if err := json.Unmarshal([]byte(unquoted), &decoded); err != nil {
+			break
+		}
+		appendCandidate(decoded)
+		unquoted = strings.TrimSpace(decoded)
+	}
+
+	segments := extractBalancedJSONSegments(raw)
+	for _, segment := range segments {
+		appendCandidate(segment)
+	}
+
+	return candidates
+}
+
+func extractBalancedJSONSegments(raw string) []string {
+	const maxSegments = 6
+	segments := make([]string, 0, 2)
+
+	for index := 0; index < len(raw) && len(segments) < maxSegments; index++ {
+		ch := raw[index]
+		if ch != '{' && ch != '[' {
+			continue
+		}
+		segment, ok := balancedJSONFrom(raw, index)
+		if !ok {
+			continue
+		}
+		segments = append(segments, segment)
+		index += len(segment) - 1
+	}
+
+	return segments
+}
+
+func balancedJSONFrom(raw string, start int) (string, bool) {
+	if start < 0 || start >= len(raw) {
+		return "", false
+	}
+
+	switch raw[start] {
+	case '{', '[':
+	default:
+		return "", false
+	}
+
+	stack := make([]byte, 0, 8)
+	inString := false
+	escaped := false
+
+	for index := start; index < len(raw); index++ {
+		ch := raw[index]
+
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if ch == '\\' {
+				escaped = true
+				continue
+			}
+			if ch == '"' {
+				inString = false
+			}
+			continue
+		}
+
+		switch ch {
+		case '"':
+			inString = true
+		case '{', '[':
+			stack = append(stack, ch)
+		case '}':
+			if len(stack) == 0 || stack[len(stack)-1] != '{' {
+				return "", false
+			}
+			stack = stack[:len(stack)-1]
+		case ']':
+			if len(stack) == 0 || stack[len(stack)-1] != '[' {
+				return "", false
+			}
+			stack = stack[:len(stack)-1]
+		}
+
+		if len(stack) == 0 {
+			return raw[start : index+1], true
+		}
+	}
+
+	return "", false
 }
 
 func normalizeResults(entries []classificationResultPayload, messages []types.EmailSummary) ([]types.ClassificationResult, error) {

--- a/internal/claude/client_test.go
+++ b/internal/claude/client_test.go
@@ -197,6 +197,90 @@ func TestClassifyRejectsMissingResult(t *testing.T) {
 	}
 }
 
+func TestClassifyParsesJSONEmbeddedInText(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient(Options{
+		BaseURL:      "https://claude.test",
+		DefaultModel: "claude-test-model",
+		HTTPClient: &http.Client{
+			Transport: claudeRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+					Body: io.NopCloser(strings.NewReader(`{
+							"content":[
+								{
+									"type":"text",
+									"text":"以下が分類結果です。\n結果: [{\"id\":\"msg-1\",\"category\":\"important\",\"confidence\":0.91,\"reason\":\"要返信\"}]\n確認してください。"
+								}
+							]
+						}`)),
+				}, nil
+			}),
+		},
+	})
+
+	result, err := client.Classify(context.Background(), "claude-secret", types.ClassificationRequest{
+		Messages: []types.EmailSummary{
+			{ID: "msg-1", Subject: "subject"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Classify returned error: %v", err)
+	}
+	if len(result.Results) != 1 {
+		t.Fatalf("Results length = %d, want 1", len(result.Results))
+	}
+	if result.Results[0].MessageID != "msg-1" {
+		t.Fatalf("MessageID = %q, want %q", result.Results[0].MessageID, "msg-1")
+	}
+}
+
+func TestClassifySkipsMismatchedCandidateAndUsesLaterValidCandidate(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient(Options{
+		BaseURL:      "https://claude.test",
+		DefaultModel: "claude-test-model",
+		HTTPClient: &http.Client{
+			Transport: claudeRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+					Body: io.NopCloser(strings.NewReader(`{
+						"content":[
+							{
+								"type":"text",
+								"text":"補助情報: []\n最終結果: [{\"id\":\"msg-1\",\"category\":\"important\",\"confidence\":0.91,\"reason\":\"要返信\"}]"
+							}
+						]
+					}`)),
+				}, nil
+			}),
+		},
+	})
+
+	result, err := client.Classify(context.Background(), "claude-secret", types.ClassificationRequest{
+		Messages: []types.EmailSummary{
+			{ID: "msg-1", Subject: "subject"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Classify returned error: %v", err)
+	}
+	if len(result.Results) != 1 {
+		t.Fatalf("Results length = %d, want 1", len(result.Results))
+	}
+	if result.Results[0].MessageID != "msg-1" {
+		t.Fatalf("MessageID = %q, want %q", result.Results[0].MessageID, "msg-1")
+	}
+}
+
 type claudeRoundTripFunc func(*http.Request) (*http.Response, error)
 
 func (fn claudeRoundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {

--- a/internal/claude/client_test.go
+++ b/internal/claude/client_test.go
@@ -239,6 +239,48 @@ func TestClassifyParsesJSONEmbeddedInText(t *testing.T) {
 	}
 }
 
+func TestClassifyParsesJSONEmbeddedInDecodedJSONString(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient(Options{
+		BaseURL:      "https://claude.test",
+		DefaultModel: "claude-test-model",
+		HTTPClient: &http.Client{
+			Transport: claudeRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+					Body: io.NopCloser(strings.NewReader(`{
+							"content":[
+								{
+									"type":"text",
+									"text":"\"結果: [{\\\"id\\\":\\\"msg-1\\\",\\\"category\\\":\\\"important\\\",\\\"confidence\\\":0.91,\\\"reason\\\":\\\"要返信\\\"}]\""
+								}
+							]
+						}`)),
+				}, nil
+			}),
+		},
+	})
+
+	result, err := client.Classify(context.Background(), "claude-secret", types.ClassificationRequest{
+		Messages: []types.EmailSummary{
+			{ID: "msg-1", Subject: "subject"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Classify returned error: %v", err)
+	}
+	if len(result.Results) != 1 {
+		t.Fatalf("Results length = %d, want 1", len(result.Results))
+	}
+	if result.Results[0].MessageID != "msg-1" {
+		t.Fatalf("MessageID = %q, want %q", result.Results[0].MessageID, "msg-1")
+	}
+}
+
 func TestClassifySkipsMismatchedCandidateAndUsesLaterValidCandidate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gmail/client_test.go
+++ b/internal/gmail/client_test.go
@@ -273,6 +273,88 @@ func TestFetchMessagesSkipsMessageDetailFailures(t *testing.T) {
 	}
 }
 
+func TestFetchMessageDetail(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient(Options{
+		BaseURL: "https://gmail.test",
+		HTTPClient: &http.Client{
+			Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				if got := r.Header.Get("Authorization"); got != "Bearer access-token" {
+					t.Fatalf("Authorization mismatch: got %q", got)
+				}
+				if r.Method != http.MethodGet {
+					t.Fatalf("unexpected method: got %s, want %s", r.Method, http.MethodGet)
+				}
+				if r.URL.String() != "https://gmail.test/gmail/v1/users/me/messages/m1?format=full" {
+					t.Fatalf("unexpected URL: got %s", r.URL.String())
+				}
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+					Body: io.NopCloser(strings.NewReader(`{
+						"id":"m1",
+						"threadId":"t1",
+						"snippet":"first message",
+						"labelIds":["INBOX","UNREAD"],
+						"payload":{
+							"mimeType":"multipart/alternative",
+							"headers":[
+								{"name":"From","value":"alpha@example.com"},
+								{"name":"To","value":"user@example.com"},
+								{"name":"Subject","value":"subject-1"},
+								{"name":"Date","value":"Sun, 15 Mar 2026 12:00:00 +0900"}
+							],
+							"parts":[
+								{"mimeType":"text/plain","body":{"data":"SGVsbG8gcGxhaW4gYm9keQ"}},
+								{"mimeType":"text/html","body":{"data":"PHA-SGVsbG8gaHRtbCBib2R5PC9wPg"}}
+							]
+						}
+					}`)),
+				}, nil
+			}),
+		},
+	})
+
+	result, err := client.FetchMessageDetail(context.Background(), "access-token", "m1")
+	if err != nil {
+		t.Fatalf("FetchMessageDetail returned error: %v", err)
+	}
+	if result.ID != "m1" {
+		t.Fatalf("ID = %q, want %q", result.ID, "m1")
+	}
+	if result.ThreadID != "t1" {
+		t.Fatalf("ThreadID = %q, want %q", result.ThreadID, "t1")
+	}
+	if result.From != "alpha@example.com" {
+		t.Fatalf("From = %q, want %q", result.From, "alpha@example.com")
+	}
+	if result.To != "user@example.com" {
+		t.Fatalf("To = %q, want %q", result.To, "user@example.com")
+	}
+	if result.Subject != "subject-1" {
+		t.Fatalf("Subject = %q, want %q", result.Subject, "subject-1")
+	}
+	if result.Date != "Sun, 15 Mar 2026 12:00:00 +0900" {
+		t.Fatalf("Date = %q", result.Date)
+	}
+	if result.BodyText != "Hello plain body" {
+		t.Fatalf("BodyText = %q, want %q", result.BodyText, "Hello plain body")
+	}
+	if result.BodyHTML != "<p>Hello html body</p>" {
+		t.Fatalf("BodyHTML = %q, want %q", result.BodyHTML, "<p>Hello html body</p>")
+	}
+	if !result.Unread {
+		t.Fatalf("Unread = false, want true")
+	}
+	if len(result.Headers) != 4 {
+		t.Fatalf("len(Headers) = %d, want 4", len(result.Headers))
+	}
+}
+
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (fn roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {

--- a/internal/gmail/client_test.go
+++ b/internal/gmail/client_test.go
@@ -355,6 +355,53 @@ func TestFetchMessageDetail(t *testing.T) {
 	}
 }
 
+func TestFetchMessageDetailIgnoresNonTextLeafParts(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient(Options{
+		BaseURL: "https://gmail.test",
+		HTTPClient: &http.Client{
+			Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+					Body: io.NopCloser(strings.NewReader(`{
+						"id":"m2",
+						"threadId":"t2",
+						"snippet":"body",
+						"labelIds":["INBOX"],
+						"payload":{
+							"mimeType":"multipart/mixed",
+							"headers":[
+								{"name":"From","value":"alpha@example.com"},
+								{"name":"Subject","value":"subject-2"}
+							],
+							"parts":[
+								{"mimeType":"application/pdf","body":{"data":"UERGQklO"}},
+								{"mimeType":"image/png","body":{"data":"aW1hZ2U"}},
+								{"mimeType":"text/plain","body":{"data":"VGV4dCBib2R5"}}
+							]
+						}
+					}`)),
+				}, nil
+			}),
+		},
+	})
+
+	result, err := client.FetchMessageDetail(context.Background(), "access-token", "m2")
+	if err != nil {
+		t.Fatalf("FetchMessageDetail returned error: %v", err)
+	}
+	if result.BodyText != "Text body" {
+		t.Fatalf("BodyText = %q, want %q", result.BodyText, "Text body")
+	}
+	if result.BodyHTML != "" {
+		t.Fatalf("BodyHTML = %q, want empty", result.BodyHTML)
+	}
+}
+
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (fn roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {

--- a/internal/gmail/labels.go
+++ b/internal/gmail/labels.go
@@ -1,0 +1,58 @@
+package gmail
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	"mairu/internal/types"
+)
+
+// ListLabels は Gmail ラベル一覧を取得する。
+func (c *Client) ListLabels(ctx context.Context, accessToken string) ([]types.GmailLabel, error) {
+	trimmedToken := strings.TrimSpace(accessToken)
+	if trimmedToken == "" {
+		return nil, fmt.Errorf("Gmail API 呼び出しに必要な access token がありません")
+	}
+
+	var response listLabelsResponse
+	if err := c.doJSONRequest(
+		ctx,
+		http.MethodGet,
+		labelsPath,
+		trimmedToken,
+		"ラベル一覧取得",
+		nil,
+		&response,
+	); err != nil {
+		return nil, err
+	}
+
+	labels := make([]types.GmailLabel, 0, len(response.Labels))
+	for _, label := range response.Labels {
+		id := strings.TrimSpace(label.ID)
+		name := strings.TrimSpace(label.Name)
+		labelType := strings.TrimSpace(label.Type)
+		if id == "" || name == "" {
+			continue
+		}
+		labels = append(labels, types.GmailLabel{
+			ID:   id,
+			Name: name,
+			Type: labelType,
+		})
+	}
+
+	sort.Slice(labels, func(i int, j int) bool {
+		left := strings.ToLower(labels[i].Name)
+		right := strings.ToLower(labels[j].Name)
+		if left == right {
+			return labels[i].ID < labels[j].ID
+		}
+		return left < right
+	})
+
+	return labels, nil
+}

--- a/internal/gmail/message_detail.go
+++ b/internal/gmail/message_detail.go
@@ -1,0 +1,170 @@
+package gmail
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"mairu/internal/types"
+)
+
+type messageBodyDTO struct {
+	Data string `json:"data"`
+}
+
+type messageDetailPayloadDTO struct {
+	MimeType string                    `json:"mimeType"`
+	Headers  []messageHeaderDTO        `json:"headers"`
+	Body     messageBodyDTO            `json:"body"`
+	Parts    []messageDetailPayloadDTO `json:"parts"`
+}
+
+type fullMessageDetailResponse struct {
+	ID       string                  `json:"id"`
+	ThreadID string                  `json:"threadId"`
+	Snippet  string                  `json:"snippet"`
+	LabelIDs []string                `json:"labelIds"`
+	Payload  messageDetailPayloadDTO `json:"payload"`
+}
+
+// FetchMessageDetail は Gmail メール 1 通分の詳細情報を取得する。
+func (c *Client) FetchMessageDetail(
+	ctx context.Context,
+	accessToken string,
+	messageID string,
+) (types.GmailMessageDetail, error) {
+	trimmedToken := strings.TrimSpace(accessToken)
+	if trimmedToken == "" {
+		return types.GmailMessageDetail{}, fmt.Errorf("Gmail API 呼び出しに必要な access token がありません")
+	}
+	trimmedMessageID := strings.TrimSpace(messageID)
+	if trimmedMessageID == "" {
+		return types.GmailMessageDetail{}, fmt.Errorf("messageID を入力してください")
+	}
+
+	var detail fullMessageDetailResponse
+	detailPath := fmt.Sprintf("%s?format=full", fmt.Sprintf(messageDetailPath, url.PathEscape(trimmedMessageID)))
+	if err := c.doJSONRequest(
+		ctx,
+		http.MethodGet,
+		detailPath,
+		trimmedToken,
+		"メール詳細取得",
+		nil,
+		&detail,
+	); err != nil {
+		return types.GmailMessageDetail{}, err
+	}
+
+	bodyText, bodyHTML := collectMessageBodies(detail.Payload)
+	headers := sanitizeHeaders(detail.Payload.Headers)
+
+	result := types.GmailMessageDetail{
+		ID:       strings.TrimSpace(detail.ID),
+		ThreadID: strings.TrimSpace(detail.ThreadID),
+		From:     messageHeaderValue(detail.Payload.Headers, "From"),
+		To:       messageHeaderValue(detail.Payload.Headers, "To"),
+		Subject:  messageHeaderValue(detail.Payload.Headers, "Subject"),
+		Date:     messageHeaderValue(detail.Payload.Headers, "Date"),
+		Snippet:  strings.TrimSpace(detail.Snippet),
+		LabelIDs: sanitizeLabelIDs(detail.LabelIDs),
+		Unread:   messageHasLabel(detail.LabelIDs, systemLabelUnread),
+		BodyText: bodyText,
+		BodyHTML: bodyHTML,
+		Headers:  headers,
+	}
+
+	if result.ID == "" {
+		result.ID = trimmedMessageID
+	}
+
+	return result, nil
+}
+
+func collectMessageBodies(payload messageDetailPayloadDTO) (string, string) {
+	textBodies := make([]string, 0, 4)
+	htmlBodies := make([]string, 0, 2)
+	collectMessageBodyPart(payload, &textBodies, &htmlBodies)
+
+	return strings.TrimSpace(strings.Join(textBodies, "\n\n")), strings.TrimSpace(strings.Join(htmlBodies, "\n\n"))
+}
+
+func collectMessageBodyPart(
+	payload messageDetailPayloadDTO,
+	textBodies *[]string,
+	htmlBodies *[]string,
+) {
+	mimeType := strings.ToLower(strings.TrimSpace(payload.MimeType))
+	decoded := decodeMessageBodyData(payload.Body.Data)
+
+	switch mimeType {
+	case "text/plain":
+		if decoded != "" {
+			*textBodies = append(*textBodies, decoded)
+		}
+	case "text/html":
+		if decoded != "" {
+			*htmlBodies = append(*htmlBodies, decoded)
+		}
+	default:
+		if len(payload.Parts) == 0 && decoded != "" {
+			if strings.Contains(mimeType, "html") {
+				*htmlBodies = append(*htmlBodies, decoded)
+			} else {
+				*textBodies = append(*textBodies, decoded)
+			}
+		}
+	}
+
+	for _, child := range payload.Parts {
+		collectMessageBodyPart(child, textBodies, htmlBodies)
+	}
+}
+
+func decodeMessageBodyData(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+
+	decoded, err := base64.RawURLEncoding.DecodeString(trimmed)
+	if err != nil {
+		decoded, err = base64.URLEncoding.DecodeString(trimmed)
+		if err != nil {
+			return ""
+		}
+	}
+
+	return strings.TrimSpace(string(decoded))
+}
+
+func sanitizeHeaders(headers []messageHeaderDTO) []types.GmailMessageHeader {
+	sanitized := make([]types.GmailMessageHeader, 0, len(headers))
+	for _, header := range headers {
+		name := strings.TrimSpace(header.Name)
+		value := strings.TrimSpace(header.Value)
+		if name == "" || value == "" {
+			continue
+		}
+		sanitized = append(sanitized, types.GmailMessageHeader{
+			Name:  name,
+			Value: value,
+		})
+	}
+	return sanitized
+}
+
+func sanitizeLabelIDs(labelIDs []string) []string {
+	sanitized := make([]string, 0, len(labelIDs))
+	for _, labelID := range labelIDs {
+		trimmed := strings.TrimSpace(labelID)
+		if trimmed == "" {
+			continue
+		}
+		sanitized = append(sanitized, trimmed)
+	}
+	return sanitized
+}

--- a/internal/gmail/message_detail.go
+++ b/internal/gmail/message_detail.go
@@ -111,9 +111,10 @@ func collectMessageBodyPart(
 		}
 	default:
 		if len(payload.Parts) == 0 && decoded != "" {
-			if strings.Contains(mimeType, "html") {
+			switch {
+			case strings.Contains(mimeType, "html"):
 				*htmlBodies = append(*htmlBodies, decoded)
-			} else {
+			case mimeType == "" || strings.HasPrefix(mimeType, "text/"):
 				*textBodies = append(*textBodies, decoded)
 			}
 		}

--- a/internal/types/dto.go
+++ b/internal/types/dto.go
@@ -125,6 +125,56 @@ type ClassificationResponse struct {
 	Results []ClassificationResult
 }
 
+// FetchClassificationMessagesRequest は Classify 画面向け Gmail 取得条件を表す。
+type FetchClassificationMessagesRequest struct {
+	Query      string
+	MaxResults int
+	LabelIDs   []string
+	PageToken  string
+}
+
+// FetchClassificationMessagesResult は Classify 画面向け Gmail 取得結果を表す。
+type FetchClassificationMessagesResult struct {
+	Messages       []EmailSummary
+	NextPageToken  string
+	TokenRefreshed bool
+}
+
+// GmailLabel は Gmail ラベルの最小情報を表す。
+type GmailLabel struct {
+	ID   string
+	Name string
+	Type string
+}
+
+// ListGmailLabelsResult は Gmail ラベル一覧取得結果を表す。
+type ListGmailLabelsResult struct {
+	Labels         []GmailLabel
+	TokenRefreshed bool
+}
+
+// GmailMessageHeader はメールヘッダ 1 件を表す。
+type GmailMessageHeader struct {
+	Name  string
+	Value string
+}
+
+// GmailMessageDetail は 1 通分の詳細情報を表す。
+type GmailMessageDetail struct {
+	ID       string
+	ThreadID string
+	From     string
+	To       string
+	Subject  string
+	Date     string
+	Snippet  string
+	LabelIDs []string
+	Unread   bool
+	BodyText string
+	BodyHTML string
+	Headers  []GmailMessageHeader
+}
+
 // BlocklistKind はブロックリストの登録単位を表す。
 type BlocklistKind string
 


### PR DESCRIPTION
## 関連
- MAIRU-024
- #48

## 概要
Classify画面をサンプル主導の確認UIから、実メール取得を起点にした手動運用フローへ移行しました。

## 変更内容
- 実メール取得APIを追加（query / maxResults / labelIDs / pageToken）
- Gmailラベル一覧の自動取得APIを追加し、Classify画面で複数選択可能に変更
- 取得メール一覧を追加し、各メールの詳細（本文テキスト/HTMLソース/ヘッダ）を表示可能に変更
- Claude分類エラー表示を改善（Wails経由の非Error形式も表示）
- Claude応答パーサーを強化（説明文に埋め込まれたJSON候補を探索して解釈）
- Gmail反映前の確認を `window.confirm` から画面内確認パネルへ変更
- 取得件数入力のUXを改善（入力中は文字列保持、実行時に1-50へ正規化）
- 追加したバックエンド/パーサーのテストを拡充

## 実行コマンド
- `go test ./...`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run test`

## テスト結果
- すべて成功

Closes #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Gmail連携を追加：メッセージ取得（クエリ・件数・ページング・ラベル指定）、ラベル一覧、メッセージ詳細表示をサポート
  * 分類画面UI拡張：クエリ/件数/ラベル選択、サンプル／モック／ライブ切替、確認パネル、詳細ビュー、履歴表示、レスポンシブ調整

* **改善**
  * 分類結果のJSON解析耐性を強化（埋め込みJSONや複数候補の許容）
  * トークン管理とリフレッシュ処理の信頼性向上

* **テスト**
  * Gmail/OAuth/分類周りの単体テストを多数追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->