### PR TITLE
[MAIRU-025 / #50] 自動分別ラベル名をユーザー設定可能にする

### DIFF
--- a/app.go
+++ b/app.go
@@ -49,6 +49,12 @@ const (
 	schedulerSettingLastRunTemplate          = "scheduler.%s.last_run_at"
 	schedulerSettingClassificationCheckpoint = "scheduler.classification.checkpoint"
 
+	classificationLabelSettingImportant      = "classification.labels.important"
+	classificationLabelSettingNewsletter     = "classification.labels.newsletter"
+	classificationLabelSettingArchive        = "classification.labels.archive"
+	classificationLabelSettingUnreadPriority = "classification.labels.unread_priority"
+	classificationLabelSettingNeedsReview    = "classification.labels.needs_review"
+
 	schedulerJobClassification = "classification_daily"
 	schedulerJobBlocklist      = "blocklist_daily"
 	schedulerJobKnownBlock     = "known_block_30m"
@@ -360,6 +366,88 @@ func (a *App) UpdateSchedulerSettings(request types.UpdateSchedulerSettingsReque
 	return types.OperationResult{
 		Success: true,
 		Message: "自動実行設定を保存しました。",
+	}
+}
+
+// GetClassificationLabelSettings は自動分別ラベル名の設定を返す。
+func (a *App) GetClassificationLabelSettings() types.ClassificationLabelSettings {
+	settings := types.DefaultClassificationLabelSettings()
+
+	store, err := a.requireDBStore()
+	if err != nil {
+		return settings
+	}
+
+	ctx, cancel := context.WithTimeout(a.baseContext(), dbOperationTimeout)
+	defer cancel()
+
+	settings.ImportantLabelName = a.loadClassificationLabelSetting(
+		ctx,
+		store,
+		classificationLabelSettingImportant,
+		settings.ImportantLabelName,
+	)
+	settings.NewsletterLabelName = a.loadClassificationLabelSetting(
+		ctx,
+		store,
+		classificationLabelSettingNewsletter,
+		settings.NewsletterLabelName,
+	)
+	settings.ArchiveLabelName = a.loadClassificationLabelSetting(
+		ctx,
+		store,
+		classificationLabelSettingArchive,
+		settings.ArchiveLabelName,
+	)
+	settings.UnreadPriorityLabelName = a.loadClassificationLabelSetting(
+		ctx,
+		store,
+		classificationLabelSettingUnreadPriority,
+		settings.UnreadPriorityLabelName,
+	)
+	settings.NeedsReviewLabelName = a.loadClassificationLabelSetting(
+		ctx,
+		store,
+		classificationLabelSettingNeedsReview,
+		settings.NeedsReviewLabelName,
+	)
+
+	return types.NormalizeClassificationLabelSettings(settings)
+}
+
+// UpdateClassificationLabelSettings は自動分別ラベル名の設定を保存する。
+func (a *App) UpdateClassificationLabelSettings(
+	request types.UpdateClassificationLabelSettingsRequest,
+) types.OperationResult {
+	store, err := a.requireDBStore()
+	if err != nil {
+		return types.OperationResult{
+			Success: false,
+			Message: err.Error(),
+		}
+	}
+
+	next := types.NormalizeClassificationLabelSettings(types.ClassificationLabelSettings{
+		ImportantLabelName:      request.ImportantLabelName,
+		NewsletterLabelName:     request.NewsletterLabelName,
+		ArchiveLabelName:        request.ArchiveLabelName,
+		UnreadPriorityLabelName: request.UnreadPriorityLabelName,
+		NeedsReviewLabelName:    request.NeedsReviewLabelName,
+	})
+
+	ctx, cancel := context.WithTimeout(a.baseContext(), dbOperationTimeout)
+	defer cancel()
+
+	if err := store.SetSettings(ctx, classificationLabelSettingsValueMap(next)); err != nil {
+		return types.OperationResult{
+			Success: false,
+			Message: fmt.Sprintf("分類ラベル設定を保存できませんでした: %v", err),
+		}
+	}
+
+	return types.OperationResult{
+		Success: true,
+		Message: "分類ラベル設定を保存しました。",
 	}
 }
 
@@ -713,7 +801,13 @@ func (a *App) ExecuteGmailActions(
 		Message: "実行対象がありませんでした。",
 	}
 	if len(executionRequest.Decisions) > 0 {
-		result, err = a.gmailClient.ExecuteActions(baseContext, token.AccessToken, executionRequest.Decisions)
+		labelSettings := a.GetClassificationLabelSettings()
+		result, err = a.gmailClient.ExecuteActions(
+			baseContext,
+			token.AccessToken,
+			executionRequest.Decisions,
+			labelSettings,
+		)
 		if err != nil {
 			return types.ExecuteGmailActionsResult{}, err
 		}
@@ -1540,6 +1634,28 @@ func (a *App) loadSchedulerNotificationsEnabled(ctx context.Context, store *db.S
 	}
 }
 
+func (a *App) loadClassificationLabelSetting(
+	ctx context.Context,
+	store *db.Store,
+	settingKey string,
+	fallback string,
+) string {
+	value, ok, err := store.GetSetting(ctx, settingKey)
+	if err != nil {
+		log.Printf("分類ラベル設定の読み出しに失敗しました key=%s: %v", settingKey, err)
+		return fallback
+	}
+	if !ok {
+		return fallback
+	}
+
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return fallback
+	}
+	return trimmed
+}
+
 func defaultSchedulerSettings() types.SchedulerSettings {
 	return types.SchedulerSettings{
 		ClassificationIntervalMinutes: defaultClassificationIntervalMinutes,
@@ -1566,6 +1682,16 @@ func schedulerSettingsValueMap(settings types.SchedulerSettings) map[string]stri
 		schedulerSettingBlocklistMinutes:      strconv.Itoa(settings.BlocklistIntervalMinutes),
 		schedulerSettingKnownBlockMinutes:     strconv.Itoa(settings.KnownBlockIntervalMinutes),
 		schedulerSettingNotificationsEnabled:  strconv.FormatBool(settings.NotificationsEnabled),
+	}
+}
+
+func classificationLabelSettingsValueMap(settings types.ClassificationLabelSettings) map[string]string {
+	return map[string]string{
+		classificationLabelSettingImportant:      settings.ImportantLabelName,
+		classificationLabelSettingNewsletter:     settings.NewsletterLabelName,
+		classificationLabelSettingArchive:        settings.ArchiveLabelName,
+		classificationLabelSettingUnreadPriority: settings.UnreadPriorityLabelName,
+		classificationLabelSettingNeedsReview:    settings.NeedsReviewLabelName,
 	}
 }
 

--- a/app.go
+++ b/app.go
@@ -71,6 +71,24 @@ const (
 	schedulerNotificationEventName = "scheduler:notification"
 )
 
+var reservedGmailSystemLabelNames = map[string]struct{}{
+	"INBOX":               {},
+	"UNREAD":              {},
+	"SENT":                {},
+	"DRAFT":               {},
+	"TRASH":               {},
+	"SPAM":                {},
+	"STARRED":             {},
+	"IMPORTANT":           {},
+	"CHAT":                {},
+	"SNOOZED":             {},
+	"CATEGORY_PERSONAL":   {},
+	"CATEGORY_SOCIAL":     {},
+	"CATEGORY_PROMOTIONS": {},
+	"CATEGORY_UPDATES":    {},
+	"CATEGORY_FORUMS":     {},
+}
+
 type classificationCheckpoint struct {
 	RunType          string   `json:"run_type"`
 	Mode             string   `json:"mode"`
@@ -434,6 +452,12 @@ func (a *App) UpdateClassificationLabelSettings(
 		UnreadPriorityLabelName: request.UnreadPriorityLabelName,
 		NeedsReviewLabelName:    request.NeedsReviewLabelName,
 	})
+	if err := validateClassificationLabelSettings(next); err != nil {
+		return types.OperationResult{
+			Success: false,
+			Message: fmt.Sprintf("分類ラベル設定の入力が不正です: %v", err),
+		}
+	}
 
 	ctx, cancel := context.WithTimeout(a.baseContext(), dbOperationTimeout)
 	defer cancel()
@@ -785,6 +809,14 @@ func (a *App) ExecuteGmailActions(
 		return types.ExecuteGmailActionsResult{}, fmt.Errorf("重複防止に必要な DB ストアを初期化できませんでした: %w", storeErr)
 	}
 
+	labelSettings := types.ClassificationLabelSettings{}
+	if len(request.Decisions) > 0 {
+		labelSettings, err = a.getClassificationLabelSettingsStrict(baseContext, store)
+		if err != nil {
+			return types.ExecuteGmailActionsResult{}, fmt.Errorf("分類ラベル設定を読み出せませんでした: %w", err)
+		}
+	}
+
 	executionRequest := request
 	skippedLogEntries := make([]types.ActionLogEntry, 0)
 	executionRequest, skippedLogEntries, err = a.excludeAlreadySucceededActions(
@@ -801,7 +833,6 @@ func (a *App) ExecuteGmailActions(
 		Message: "実行対象がありませんでした。",
 	}
 	if len(executionRequest.Decisions) > 0 {
-		labelSettings := a.GetClassificationLabelSettings()
 		result, err = a.gmailClient.ExecuteActions(
 			baseContext,
 			token.AccessToken,
@@ -1654,6 +1685,112 @@ func (a *App) loadClassificationLabelSetting(
 		return fallback
 	}
 	return trimmed
+}
+
+func (a *App) loadClassificationLabelSettingStrict(
+	ctx context.Context,
+	store *db.Store,
+	settingKey string,
+	fallback string,
+) (string, error) {
+	value, ok, err := store.GetSetting(ctx, settingKey)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return fallback, nil
+	}
+
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return fallback, nil
+	}
+	return trimmed, nil
+}
+
+func (a *App) getClassificationLabelSettingsStrict(
+	ctx context.Context,
+	store *db.Store,
+) (types.ClassificationLabelSettings, error) {
+	settings := types.DefaultClassificationLabelSettings()
+
+	var err error
+	settings.ImportantLabelName, err = a.loadClassificationLabelSettingStrict(
+		ctx,
+		store,
+		classificationLabelSettingImportant,
+		settings.ImportantLabelName,
+	)
+	if err != nil {
+		return types.ClassificationLabelSettings{}, fmt.Errorf("重要ラベル設定の読み出しに失敗しました: %w", err)
+	}
+	settings.NewsletterLabelName, err = a.loadClassificationLabelSettingStrict(
+		ctx,
+		store,
+		classificationLabelSettingNewsletter,
+		settings.NewsletterLabelName,
+	)
+	if err != nil {
+		return types.ClassificationLabelSettings{}, fmt.Errorf("ニュースレターラベル設定の読み出しに失敗しました: %w", err)
+	}
+	settings.ArchiveLabelName, err = a.loadClassificationLabelSettingStrict(
+		ctx,
+		store,
+		classificationLabelSettingArchive,
+		settings.ArchiveLabelName,
+	)
+	if err != nil {
+		return types.ClassificationLabelSettings{}, fmt.Errorf("アーカイブラベル設定の読み出しに失敗しました: %w", err)
+	}
+	settings.UnreadPriorityLabelName, err = a.loadClassificationLabelSettingStrict(
+		ctx,
+		store,
+		classificationLabelSettingUnreadPriority,
+		settings.UnreadPriorityLabelName,
+	)
+	if err != nil {
+		return types.ClassificationLabelSettings{}, fmt.Errorf("未読優先ラベル設定の読み出しに失敗しました: %w", err)
+	}
+	settings.NeedsReviewLabelName, err = a.loadClassificationLabelSettingStrict(
+		ctx,
+		store,
+		classificationLabelSettingNeedsReview,
+		settings.NeedsReviewLabelName,
+	)
+	if err != nil {
+		return types.ClassificationLabelSettings{}, fmt.Errorf("要確認ラベル設定の読み出しに失敗しました: %w", err)
+	}
+
+	normalized := types.NormalizeClassificationLabelSettings(settings)
+	if err := validateClassificationLabelSettings(normalized); err != nil {
+		return types.ClassificationLabelSettings{}, err
+	}
+	return normalized, nil
+}
+
+func validateClassificationLabelSettings(settings types.ClassificationLabelSettings) error {
+	candidates := []struct {
+		name  string
+		value string
+	}{
+		{name: "重要ラベル", value: settings.ImportantLabelName},
+		{name: "ニュースレターラベル", value: settings.NewsletterLabelName},
+		{name: "アーカイブラベル", value: settings.ArchiveLabelName},
+		{name: "未読優先ラベル", value: settings.UnreadPriorityLabelName},
+		{name: "要確認ラベル", value: settings.NeedsReviewLabelName},
+	}
+
+	for _, candidate := range candidates {
+		trimmed := strings.TrimSpace(candidate.value)
+		if trimmed == "" {
+			continue
+		}
+		normalized := strings.ToUpper(trimmed)
+		if _, exists := reservedGmailSystemLabelNames[normalized]; exists {
+			return fmt.Errorf("%sに Gmail システムラベル名 %q は指定できません", candidate.name, trimmed)
+		}
+	}
+	return nil
 }
 
 func defaultSchedulerSettings() types.SchedulerSettings {

--- a/app_test.go
+++ b/app_test.go
@@ -1375,6 +1375,192 @@ func TestUpdateSchedulerSettingsPersistsValues(t *testing.T) {
 	}
 }
 
+func TestGetClassificationLabelSettingsReturnsDefaultsWhenDBUnavailable(t *testing.T) {
+	t.Parallel()
+
+	app := &App{}
+	got := app.GetClassificationLabelSettings()
+	want := types.DefaultClassificationLabelSettings()
+
+	if got != want {
+		t.Fatalf("GetClassificationLabelSettings = %+v, want %+v", got, want)
+	}
+}
+
+func TestUpdateClassificationLabelSettingsPersistsValues(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store, err := db.Open(ctx, db.OpenOptions{
+		Path: filepath.Join(t.TempDir(), "mairu.db"),
+	})
+	if err != nil {
+		t.Fatalf("db.Open returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Fatalf("store.Close returned error: %v", err)
+		}
+	})
+
+	app := &App{
+		ctx:           ctx,
+		dbStore:       store,
+		databaseReady: true,
+	}
+
+	result := app.UpdateClassificationLabelSettings(types.UpdateClassificationLabelSettingsRequest{
+		ImportantLabelName:      " Team/Important ",
+		NewsletterLabelName:     "",
+		ArchiveLabelName:        "Team/Archive",
+		UnreadPriorityLabelName: " ",
+		NeedsReviewLabelName:    "Team/Review",
+	})
+	if !result.Success {
+		t.Fatalf("UpdateClassificationLabelSettings success = false, message=%q", result.Message)
+	}
+
+	got := app.GetClassificationLabelSettings()
+	if got.ImportantLabelName != "Team/Important" {
+		t.Fatalf("ImportantLabelName = %q, want %q", got.ImportantLabelName, "Team/Important")
+	}
+	if got.NewsletterLabelName != types.DefaultClassificationLabelNewsletter {
+		t.Fatalf("NewsletterLabelName = %q, want default", got.NewsletterLabelName)
+	}
+	if got.ArchiveLabelName != "Team/Archive" {
+		t.Fatalf("ArchiveLabelName = %q, want %q", got.ArchiveLabelName, "Team/Archive")
+	}
+	if got.UnreadPriorityLabelName != types.DefaultClassificationLabelUnreadPriority {
+		t.Fatalf("UnreadPriorityLabelName = %q, want default", got.UnreadPriorityLabelName)
+	}
+	if got.NeedsReviewLabelName != "Team/Review" {
+		t.Fatalf("NeedsReviewLabelName = %q, want %q", got.NeedsReviewLabelName, "Team/Review")
+	}
+}
+
+func TestExecuteGmailActionsUsesCustomClassificationLabelSettings(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store, err := db.Open(ctx, db.OpenOptions{
+		Path: filepath.Join(t.TempDir(), "mairu.db"),
+	})
+	if err != nil {
+		t.Fatalf("db.Open returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Fatalf("store.Close returned error: %v", err)
+		}
+	})
+
+	if err := store.SetSetting(ctx, classificationLabelSettingImportant, "Team/Important"); err != nil {
+		t.Fatalf("SetSetting returned error: %v", err)
+	}
+
+	secretStore := auth.NewMemorySecretStore()
+	manager := auth.NewSecretManager(secretStore)
+	if err := manager.SaveGoogleToken(ctx, auth.TokenSet{AccessToken: "access-token"}); err != nil {
+		t.Fatalf("SaveGoogleToken returned error: %v", err)
+	}
+
+	step := 0
+	httpClient := &http.Client{
+		Transport: appRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+			switch step {
+			case 0:
+				if r.URL.String() != "https://gmail.test/gmail/v1/users/me/labels" {
+					t.Fatalf("step0 unexpected URL: %s", r.URL.String())
+				}
+				step++
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+					Body: io.NopCloser(strings.NewReader(`{"labels":[{"id":"INBOX","name":"INBOX","type":"system"}]}`)),
+				}, nil
+			case 1:
+				if r.URL.String() != "https://gmail.test/gmail/v1/users/me/labels" {
+					t.Fatalf("step1 unexpected URL: %s", r.URL.String())
+				}
+				var payload struct {
+					Name string `json:"name"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+					t.Fatalf("step1 decode error: %v", err)
+				}
+				if payload.Name != "Team/Important" {
+					t.Fatalf("step1 label name = %q, want %q", payload.Name, "Team/Important")
+				}
+				step++
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+					Body: io.NopCloser(strings.NewReader(`{"id":"LabelImportant","name":"Team/Important","type":"user"}`)),
+				}, nil
+			case 2:
+				if r.URL.String() != "https://gmail.test/gmail/v1/users/me/messages/msg-1/modify" {
+					t.Fatalf("step2 unexpected URL: %s", r.URL.String())
+				}
+				var payload struct {
+					AddLabelIDs []string `json:"addLabelIds"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+					t.Fatalf("step2 decode error: %v", err)
+				}
+				if len(payload.AddLabelIDs) != 1 || payload.AddLabelIDs[0] != "LabelImportant" {
+					t.Fatalf("step2 addLabelIds = %v, want [LabelImportant]", payload.AddLabelIDs)
+				}
+				step++
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header: http.Header{
+						"Content-Type": []string{"application/json"},
+					},
+					Body: io.NopCloser(strings.NewReader(`{}`)),
+				}, nil
+			default:
+				t.Fatalf("unexpected step: %d", step)
+				return nil, nil
+			}
+		}),
+	}
+
+	app := &App{
+		authClient:    auth.NewClient(auth.Config{}),
+		gmailClient:   gmail.NewClient(gmail.Options{BaseURL: "https://gmail.test", HTTPClient: httpClient}),
+		secretManager: manager,
+		dbStore:       store,
+		databaseReady: true,
+	}
+
+	result, err := app.ExecuteGmailActions(types.ExecuteGmailActionsRequest{
+		Confirmed: true,
+		Decisions: []types.GmailActionDecision{
+			{
+				MessageID:   "msg-1",
+				Category:    types.ClassificationCategoryImportant,
+				ReviewLevel: types.ClassificationReviewLevelAutoApply,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteGmailActions returned error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Success = false, want true (message=%q)", result.Message)
+	}
+	if got := strings.Join(result.CreatedLabels, ","); got != "Team/Important" {
+		t.Fatalf("CreatedLabels = %v, want [Team/Important]", result.CreatedLabels)
+	}
+	if step != 3 {
+		t.Fatalf("step = %d, want 3", step)
+	}
+}
+
 func TestBuildSchedulerNotificationWithPendingApproval(t *testing.T) {
 	t.Parallel()
 

--- a/app_test.go
+++ b/app_test.go
@@ -1436,6 +1436,62 @@ func TestUpdateClassificationLabelSettingsPersistsValues(t *testing.T) {
 	if got.NeedsReviewLabelName != "Team/Review" {
 		t.Fatalf("NeedsReviewLabelName = %q, want %q", got.NeedsReviewLabelName, "Team/Review")
 	}
+
+	rawChecks := []struct {
+		key  string
+		want string
+	}{
+		{key: classificationLabelSettingImportant, want: "Team/Important"},
+		{key: classificationLabelSettingNewsletter, want: types.DefaultClassificationLabelNewsletter},
+		{key: classificationLabelSettingArchive, want: "Team/Archive"},
+		{key: classificationLabelSettingUnreadPriority, want: types.DefaultClassificationLabelUnreadPriority},
+		{key: classificationLabelSettingNeedsReview, want: "Team/Review"},
+	}
+	for _, check := range rawChecks {
+		value, ok, err := store.GetSetting(ctx, check.key)
+		if err != nil {
+			t.Fatalf("GetSetting(%q) returned error: %v", check.key, err)
+		}
+		if !ok {
+			t.Fatalf("GetSetting(%q) ok = false, want true", check.key)
+		}
+		if value != check.want {
+			t.Fatalf("GetSetting(%q) = %q, want %q", check.key, value, check.want)
+		}
+	}
+}
+
+func TestUpdateClassificationLabelSettingsRejectsReservedSystemLabel(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store, err := db.Open(ctx, db.OpenOptions{
+		Path: filepath.Join(t.TempDir(), "mairu.db"),
+	})
+	if err != nil {
+		t.Fatalf("db.Open returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Fatalf("store.Close returned error: %v", err)
+		}
+	})
+
+	app := &App{
+		ctx:           ctx,
+		dbStore:       store,
+		databaseReady: true,
+	}
+
+	result := app.UpdateClassificationLabelSettings(types.UpdateClassificationLabelSettingsRequest{
+		ImportantLabelName: "INBOX",
+	})
+	if result.Success {
+		t.Fatalf("UpdateClassificationLabelSettings success = true, want false")
+	}
+	if !strings.Contains(result.Message, "INBOX") {
+		t.Fatalf("message = %q, want contains INBOX", result.Message)
+	}
 }
 
 func TestExecuteGmailActionsUsesCustomClassificationLabelSettings(t *testing.T) {
@@ -1558,6 +1614,53 @@ func TestExecuteGmailActionsUsesCustomClassificationLabelSettings(t *testing.T) 
 	}
 	if step != 3 {
 		t.Fatalf("step = %d, want 3", step)
+	}
+}
+
+func TestExecuteGmailActionsFailsWhenStrictLabelSettingsLoadFails(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store, err := db.Open(ctx, db.OpenOptions{
+		Path: filepath.Join(t.TempDir(), "mairu.db"),
+	})
+	if err != nil {
+		t.Fatalf("db.Open returned error: %v", err)
+	}
+
+	secretStore := auth.NewMemorySecretStore()
+	manager := auth.NewSecretManager(secretStore)
+	if err := manager.SaveGoogleToken(ctx, auth.TokenSet{AccessToken: "access-token"}); err != nil {
+		t.Fatalf("SaveGoogleToken returned error: %v", err)
+	}
+
+	if err := store.Close(); err != nil {
+		t.Fatalf("store.Close returned error: %v", err)
+	}
+
+	app := &App{
+		authClient:    auth.NewClient(auth.Config{}),
+		gmailClient:   gmail.NewClient(gmail.Options{BaseURL: "https://gmail.test"}),
+		secretManager: manager,
+		dbStore:       store,
+		databaseReady: true,
+	}
+
+	_, err = app.ExecuteGmailActions(types.ExecuteGmailActionsRequest{
+		Confirmed: true,
+		Decisions: []types.GmailActionDecision{
+			{
+				MessageID:   "msg-1",
+				Category:    types.ClassificationCategoryImportant,
+				ReviewLevel: types.ClassificationReviewLevelAutoApply,
+			},
+		},
+	})
+	if err == nil {
+		t.Fatalf("ExecuteGmailActions error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "分類ラベル設定を読み出せませんでした") {
+		t.Fatalf("error = %q, want contains strict label settings error", err.Error())
 	}
 }
 

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -46,6 +46,7 @@
 | MAIRU-021 | #41 | ready | Phase 4 | `action_logs` ベースの Gmail アクション重複防止 | MAIRU-009, MAIRU-010, MAIRU-018 |
 | MAIRU-022 | #42 | blocked | Phase 4 | 手動 backlog 実行の件数上限と再開導線 | MAIRU-019, MAIRU-020, MAIRU-021 |
 | MAIRU-023 | #46 | in progress | v2+ | Google Workspace CLI (`gws`) 統合基盤の PoC | MAIRU-017 |
+| MAIRU-025 | #50 | in progress | Phase 4 | 自動分別ラベル名のユーザー任意設定 | MAIRU-009, MAIRU-014, MAIRU-019 |
 
 ## Issue 詳細
 
@@ -394,6 +395,23 @@
   - `gws` がない環境でも既存 Gmail 機能が回帰しない
   - 破壊的操作が `--dry-run` + 確認 UI を通らない限り実行されない
   - PoC の検証結果をもとに「本採用 / 見送り」の判断材料が残る
+
+### MAIRU-025: 自動分別ラベル名のユーザー任意設定
+- 状態: `in progress`
+- フェーズ: Phase 4
+- GitHub: `#50`
+- 依存: `MAIRU-009`, `MAIRU-014`, `MAIRU-019`
+- 目的: 自動分別時に付与する Gmail ラベル名を固定値から分離し、ユーザー運用に合わせてカテゴリ別に任意設定できるようにする。
+- 対応内容:
+  - カテゴリ別ラベル名（important/newsletter/archive/unread_priority/needs_review）の設定 DTO を追加する
+  - DB settings へラベル設定の保存・読み込み API を追加する
+  - Gmail アクション実行時に設定済みラベル名を優先し、未設定時は既定値を使う
+  - Settings 画面にラベル名編集 UI と保存導線を追加する
+  - 手動実行 / safe-run 自動実行の両経路で同設定が使われることをテストで担保する
+- 完了条件:
+  - Settings 画面でラベル名を変更・保存できる
+  - 手動実行・自動実行の双方で変更後ラベル名が Gmail へ反映される
+  - 空入力や未保存時に既定値へフォールバックする
 
 ## GitHub Issue 化するときの手順
 1. このファイルから対象 issue を選ぶ。

--- a/frontend/src/lib/runtime.ts
+++ b/frontend/src/lib/runtime.ts
@@ -248,6 +248,16 @@ export type SchedulerSettings = {
 
 export type UpdateSchedulerSettingsRequest = SchedulerSettings;
 
+export type ClassificationLabelSettings = {
+    importantLabelName: string;
+    newsletterLabelName: string;
+    archiveLabelName: string;
+    unreadPriorityLabelName: string;
+    needsReviewLabelName: string;
+};
+
+export type UpdateClassificationLabelSettingsRequest = ClassificationLabelSettings;
+
 export type SchedulerNotification = {
     title: string;
     body: string;
@@ -321,6 +331,36 @@ type WailsAppApi = {
         BlocklistIntervalMinutes: number;
         KnownBlockIntervalMinutes: number;
         NotificationsEnabled: boolean;
+    }) =>
+        | Promise<{
+              Success: boolean;
+              Message: string;
+          }>
+        | {
+              Success: boolean;
+              Message: string;
+          };
+    GetClassificationLabelSettings?: () =>
+        | Promise<{
+              ImportantLabelName?: string;
+              NewsletterLabelName?: string;
+              ArchiveLabelName?: string;
+              UnreadPriorityLabelName?: string;
+              NeedsReviewLabelName?: string;
+          }>
+        | {
+              ImportantLabelName?: string;
+              NewsletterLabelName?: string;
+              ArchiveLabelName?: string;
+              UnreadPriorityLabelName?: string;
+              NeedsReviewLabelName?: string;
+          };
+    UpdateClassificationLabelSettings?: (request: {
+        ImportantLabelName: string;
+        NewsletterLabelName: string;
+        ArchiveLabelName: string;
+        UnreadPriorityLabelName: string;
+        NeedsReviewLabelName: string;
     }) =>
         | Promise<{
               Success: boolean;
@@ -763,6 +803,14 @@ export const defaultSchedulerSettings: SchedulerSettings = {
     notificationsEnabled: true,
 };
 
+export const defaultClassificationLabelSettings: ClassificationLabelSettings = {
+    importantLabelName: 'Mairu/Important',
+    newsletterLabelName: 'Mairu/Newsletter',
+    archiveLabelName: 'Mairu/Archive',
+    unreadPriorityLabelName: 'Mairu/Unread Priority',
+    needsReviewLabelName: 'Mairu/Needs Review',
+};
+
 const schedulerNotificationEventName = 'scheduler:notification';
 const schedulerNotificationListeners = new Set<(notification: SchedulerNotification) => void>();
 let schedulerNotificationSubscribed = false;
@@ -839,6 +887,52 @@ export async function updateSchedulerSettings(
 
     if (!result) {
         throw new Error('自動実行設定更新 API がまだ公開されていません。');
+    }
+
+    const raw = await result;
+    return {
+        success: raw.Success,
+        message: raw.Message,
+    };
+}
+
+export async function loadClassificationLabelSettings(): Promise<ClassificationLabelSettings> {
+    const appApi = window.go?.main?.App;
+    const result = appApi?.GetClassificationLabelSettings?.();
+    const raw = result ? await result : null;
+
+    if (!raw) {
+        return defaultClassificationLabelSettings;
+    }
+
+    return {
+        importantLabelName:
+            raw.ImportantLabelName ?? defaultClassificationLabelSettings.importantLabelName,
+        newsletterLabelName:
+            raw.NewsletterLabelName ?? defaultClassificationLabelSettings.newsletterLabelName,
+        archiveLabelName:
+            raw.ArchiveLabelName ?? defaultClassificationLabelSettings.archiveLabelName,
+        unreadPriorityLabelName:
+            raw.UnreadPriorityLabelName ?? defaultClassificationLabelSettings.unreadPriorityLabelName,
+        needsReviewLabelName:
+            raw.NeedsReviewLabelName ?? defaultClassificationLabelSettings.needsReviewLabelName,
+    };
+}
+
+export async function updateClassificationLabelSettings(
+    request: UpdateClassificationLabelSettingsRequest,
+): Promise<OperationResult> {
+    const appApi = window.go?.main?.App;
+    const result = appApi?.UpdateClassificationLabelSettings?.({
+        ImportantLabelName: request.importantLabelName,
+        NewsletterLabelName: request.newsletterLabelName,
+        ArchiveLabelName: request.archiveLabelName,
+        UnreadPriorityLabelName: request.unreadPriorityLabelName,
+        NeedsReviewLabelName: request.needsReviewLabelName,
+    });
+
+    if (!result) {
+        throw new Error('分類ラベル設定更新 API がまだ公開されていません。');
     }
 
     const raw = await result;

--- a/frontend/src/pages/Settings/SettingsPage.tsx
+++ b/frontend/src/pages/Settings/SettingsPage.tsx
@@ -480,10 +480,20 @@ export function SettingsPage({ appName, status, onStatusRefresh }: SettingsPageP
                 return;
             }
 
-            const latest = await loadClassificationLabelSettings();
-            setClassificationLabelSettings(latest);
-            setClassificationLabelLoaded(true);
             setClassificationLabelMessage(result.message);
+            try {
+                const latest = await loadClassificationLabelSettings();
+                setClassificationLabelSettings(latest);
+                setClassificationLabelLoaded(true);
+            } catch (cause) {
+                const reloadMessage =
+                    cause instanceof Error
+                        ? cause.message
+                        : '分類ラベル設定の再読み込みに失敗しました。';
+                setClassificationLabelError(
+                    `保存は完了しましたが、最新設定の再取得に失敗しました: ${reloadMessage}`,
+                );
+            }
         } catch (cause) {
             const message =
                 cause instanceof Error
@@ -995,23 +1005,29 @@ export function SettingsPage({ appName, status, onStatusRefresh }: SettingsPageP
                                 {schedulerError ? <p className="settings-error-note">{schedulerError}</p> : null}
                             </div>
                         </li>
-                        <li className="settings-item">
-                            <div className="settings-item-header">
-                                <h3 className="settings-item-title">自動分別ラベル名</h3>
-                                <span className={`state-chip ${classificationLabelLoaded ? 'ready' : 'pending'}`}>
+                        <li className="rounded-[24px] border border-slate-400/15 bg-slate-900/35 p-6 shadow-[0_20px_45px_-30px_rgba(14,165,233,0.55)] backdrop-blur">
+                            <div className="flex flex-wrap items-start justify-between gap-3">
+                                <h3 className="text-lg font-semibold text-slate-50">自動分別ラベル名</h3>
+                                <span
+                                    className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold tracking-wide ${
+                                        classificationLabelLoaded
+                                            ? 'border-emerald-300/35 bg-emerald-500/10 text-emerald-200'
+                                            : 'border-slate-400/35 bg-slate-600/20 text-slate-200'
+                                    }`}
+                                >
                                     {classificationLabelLoaded ? '読込済み' : '未読込'}
                                 </span>
                             </div>
-                            <p className="settings-item-body">
+                            <p className="mt-2 text-sm leading-7 text-slate-300">
                                 分類カテゴリごとに Gmail ラベル名を任意指定できます。空欄で保存すると既定値を利用します。
                             </p>
-                            <div className="settings-action-stack">
-                                <div className="settings-scheduler-grid">
-                                    <label className="settings-field" htmlFor="label-important">
-                                        <span className="settings-field-label">重要（important）</span>
+                            <div className="mt-4 grid gap-3">
+                                <div className="grid gap-3 md:grid-cols-2">
+                                    <label className="grid gap-2" htmlFor="label-important">
+                                        <span className="text-sm font-semibold text-slate-300">重要（important）</span>
                                         <input
                                             id="label-important"
-                                            className="settings-input"
+                                            className="w-full rounded-[14px] border border-slate-400/20 bg-slate-950/40 px-3.5 py-2.5 text-slate-50 placeholder:text-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-200 disabled:cursor-not-allowed disabled:opacity-50"
                                             type="text"
                                             value={classificationLabelSettings.importantLabelName}
                                             onChange={(event) => {
@@ -1020,11 +1036,11 @@ export function SettingsPage({ appName, status, onStatusRefresh }: SettingsPageP
                                             disabled={classificationLabelPending || !classificationLabelLoaded}
                                         />
                                     </label>
-                                    <label className="settings-field" htmlFor="label-newsletter">
-                                        <span className="settings-field-label">ニュースレター（newsletter）</span>
+                                    <label className="grid gap-2" htmlFor="label-newsletter">
+                                        <span className="text-sm font-semibold text-slate-300">ニュースレター（newsletter）</span>
                                         <input
                                             id="label-newsletter"
-                                            className="settings-input"
+                                            className="w-full rounded-[14px] border border-slate-400/20 bg-slate-950/40 px-3.5 py-2.5 text-slate-50 placeholder:text-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-200 disabled:cursor-not-allowed disabled:opacity-50"
                                             type="text"
                                             value={classificationLabelSettings.newsletterLabelName}
                                             onChange={(event) => {
@@ -1033,11 +1049,11 @@ export function SettingsPage({ appName, status, onStatusRefresh }: SettingsPageP
                                             disabled={classificationLabelPending || !classificationLabelLoaded}
                                         />
                                     </label>
-                                    <label className="settings-field" htmlFor="label-archive">
-                                        <span className="settings-field-label">アーカイブ（archive）</span>
+                                    <label className="grid gap-2" htmlFor="label-archive">
+                                        <span className="text-sm font-semibold text-slate-300">アーカイブ（archive）</span>
                                         <input
                                             id="label-archive"
-                                            className="settings-input"
+                                            className="w-full rounded-[14px] border border-slate-400/20 bg-slate-950/40 px-3.5 py-2.5 text-slate-50 placeholder:text-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-200 disabled:cursor-not-allowed disabled:opacity-50"
                                             type="text"
                                             value={classificationLabelSettings.archiveLabelName}
                                             onChange={(event) => {
@@ -1046,11 +1062,11 @@ export function SettingsPage({ appName, status, onStatusRefresh }: SettingsPageP
                                             disabled={classificationLabelPending || !classificationLabelLoaded}
                                         />
                                     </label>
-                                    <label className="settings-field" htmlFor="label-unread-priority">
-                                        <span className="settings-field-label">未読優先（unread_priority）</span>
+                                    <label className="grid gap-2" htmlFor="label-unread-priority">
+                                        <span className="text-sm font-semibold text-slate-300">未読優先（unread_priority）</span>
                                         <input
                                             id="label-unread-priority"
-                                            className="settings-input"
+                                            className="w-full rounded-[14px] border border-slate-400/20 bg-slate-950/40 px-3.5 py-2.5 text-slate-50 placeholder:text-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-200 disabled:cursor-not-allowed disabled:opacity-50"
                                             type="text"
                                             value={classificationLabelSettings.unreadPriorityLabelName}
                                             onChange={(event) => {
@@ -1059,11 +1075,11 @@ export function SettingsPage({ appName, status, onStatusRefresh }: SettingsPageP
                                             disabled={classificationLabelPending || !classificationLabelLoaded}
                                         />
                                     </label>
-                                    <label className="settings-field" htmlFor="label-needs-review">
-                                        <span className="settings-field-label">要確認（needs_review）</span>
+                                    <label className="grid gap-2" htmlFor="label-needs-review">
+                                        <span className="text-sm font-semibold text-slate-300">要確認（needs_review）</span>
                                         <input
                                             id="label-needs-review"
-                                            className="settings-input"
+                                            className="w-full rounded-[14px] border border-slate-400/20 bg-slate-950/40 px-3.5 py-2.5 text-slate-50 placeholder:text-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-200 disabled:cursor-not-allowed disabled:opacity-50"
                                             type="text"
                                             value={classificationLabelSettings.needsReviewLabelName}
                                             onChange={(event) => {
@@ -1073,9 +1089,9 @@ export function SettingsPage({ appName, status, onStatusRefresh }: SettingsPageP
                                         />
                                     </label>
                                 </div>
-                                <div className="settings-action-row">
+                                <div className="flex flex-wrap items-center gap-3">
                                     <button
-                                        className="settings-action-button"
+                                        className="inline-flex items-center justify-center rounded-[14px] bg-sky-500/90 px-4 py-2.5 text-sm font-bold text-white shadow-[0_8px_18px_-12px_rgba(14,165,233,0.9)] transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:opacity-50"
                                         type="button"
                                         onClick={() => {
                                             void handleSaveClassificationLabelSettings();
@@ -1086,10 +1102,24 @@ export function SettingsPage({ appName, status, onStatusRefresh }: SettingsPageP
                                     </button>
                                 </div>
                                 {classificationLabelMessage ? (
-                                    <p className="settings-inline-note">{classificationLabelMessage}</p>
+                                    <p
+                                        className="text-sm leading-7 text-sky-100"
+                                        role="status"
+                                        aria-live="polite"
+                                        aria-atomic="true"
+                                    >
+                                        {classificationLabelMessage}
+                                    </p>
                                 ) : null}
                                 {classificationLabelError ? (
-                                    <p className="settings-error-note">{classificationLabelError}</p>
+                                    <p
+                                        className="text-sm leading-7 text-rose-300"
+                                        role="alert"
+                                        aria-live="assertive"
+                                        aria-atomic="true"
+                                    >
+                                        {classificationLabelError}
+                                    </p>
                                 ) : null}
                             </div>
                         </li>

--- a/frontend/src/pages/Settings/SettingsPage.tsx
+++ b/frontend/src/pages/Settings/SettingsPage.tsx
@@ -7,14 +7,18 @@ import {
     checkGmailConnection,
     clearClaudeAPIKey,
     cancelGoogleLogin,
+    defaultClassificationLabelSettings,
     defaultSchedulerSettings,
     getNotificationPermissionStatus,
+    loadClassificationLabelSettings,
     loadSchedulerSettings,
     previewGWSGmailDryRun,
     requestNotificationPermission,
     saveClaudeAPIKey,
     startGoogleLogin,
+    updateClassificationLabelSettings,
     updateSchedulerSettings,
+    type ClassificationLabelSettings,
     type GWSDiagnosticsResult,
     type GWSGmailDryRunResult,
     type GmailConnectionResult,
@@ -116,6 +120,12 @@ export function SettingsPage({ appName, status, onStatusRefresh }: SettingsPageP
     const [schedulerError, setSchedulerError] = useState<string | null>(null);
     const [schedulerMessage, setSchedulerMessage] = useState<string | null>(null);
     const [schedulerLoaded, setSchedulerLoaded] = useState(false);
+    const [classificationLabelSettings, setClassificationLabelSettings] =
+        useState<ClassificationLabelSettings>(defaultClassificationLabelSettings);
+    const [classificationLabelLoaded, setClassificationLabelLoaded] = useState(false);
+    const [classificationLabelPending, setClassificationLabelPending] = useState(false);
+    const [classificationLabelError, setClassificationLabelError] = useState<string | null>(null);
+    const [classificationLabelMessage, setClassificationLabelMessage] = useState<string | null>(null);
     const [notificationPermission, setNotificationPermission] = useState<NotificationPermission | 'unsupported'>(
         getNotificationPermissionStatus(),
     );
@@ -137,6 +147,7 @@ export function SettingsPage({ appName, status, onStatusRefresh }: SettingsPageP
 
         async function loadSchedulerStatus() {
             setSchedulerLoaded(false);
+            setClassificationLabelLoaded(false);
 
             try {
                 const settings = await loadSchedulerSettings();
@@ -156,6 +167,26 @@ export function SettingsPage({ appName, status, onStatusRefresh }: SettingsPageP
                         : '自動実行設定の読み込みに失敗しました。';
                 setSchedulerError(message);
                 setSchedulerLoaded(false);
+            }
+
+            try {
+                const settings = await loadClassificationLabelSettings();
+                if (cancelled) {
+                    return;
+                }
+                setClassificationLabelSettings(settings);
+                setClassificationLabelLoaded(true);
+                setClassificationLabelError(null);
+            } catch (cause) {
+                if (cancelled) {
+                    return;
+                }
+                const message =
+                    cause instanceof Error
+                        ? cause.message
+                        : '分類ラベル設定の読み込みに失敗しました。';
+                setClassificationLabelError(message);
+                setClassificationLabelLoaded(false);
             }
 
             try {
@@ -423,6 +454,44 @@ export function SettingsPage({ appName, status, onStatusRefresh }: SettingsPageP
             setSchedulerError(message);
         } finally {
             setSchedulerPending(false);
+        }
+    }
+
+    function updateClassificationLabelField(
+        key: keyof ClassificationLabelSettings,
+        value: string,
+    ) {
+        setClassificationLabelSettings((previous) => ({
+            ...previous,
+            [key]: value,
+        }));
+        setClassificationLabelMessage(null);
+    }
+
+    async function handleSaveClassificationLabelSettings() {
+        setClassificationLabelPending(true);
+        setClassificationLabelError(null);
+        setClassificationLabelMessage(null);
+
+        try {
+            const result = await updateClassificationLabelSettings(classificationLabelSettings);
+            if (!result.success) {
+                setClassificationLabelError(result.message);
+                return;
+            }
+
+            const latest = await loadClassificationLabelSettings();
+            setClassificationLabelSettings(latest);
+            setClassificationLabelLoaded(true);
+            setClassificationLabelMessage(result.message);
+        } catch (cause) {
+            const message =
+                cause instanceof Error
+                    ? cause.message
+                    : '分類ラベル設定の保存に失敗しました。';
+            setClassificationLabelError(message);
+        } finally {
+            setClassificationLabelPending(false);
         }
     }
 
@@ -924,6 +993,104 @@ export function SettingsPage({ appName, status, onStatusRefresh }: SettingsPageP
                                 </div>
                                 {schedulerMessage ? <p className="settings-inline-note">{schedulerMessage}</p> : null}
                                 {schedulerError ? <p className="settings-error-note">{schedulerError}</p> : null}
+                            </div>
+                        </li>
+                        <li className="settings-item">
+                            <div className="settings-item-header">
+                                <h3 className="settings-item-title">自動分別ラベル名</h3>
+                                <span className={`state-chip ${classificationLabelLoaded ? 'ready' : 'pending'}`}>
+                                    {classificationLabelLoaded ? '読込済み' : '未読込'}
+                                </span>
+                            </div>
+                            <p className="settings-item-body">
+                                分類カテゴリごとに Gmail ラベル名を任意指定できます。空欄で保存すると既定値を利用します。
+                            </p>
+                            <div className="settings-action-stack">
+                                <div className="settings-scheduler-grid">
+                                    <label className="settings-field" htmlFor="label-important">
+                                        <span className="settings-field-label">重要（important）</span>
+                                        <input
+                                            id="label-important"
+                                            className="settings-input"
+                                            type="text"
+                                            value={classificationLabelSettings.importantLabelName}
+                                            onChange={(event) => {
+                                                updateClassificationLabelField('importantLabelName', event.target.value);
+                                            }}
+                                            disabled={classificationLabelPending || !classificationLabelLoaded}
+                                        />
+                                    </label>
+                                    <label className="settings-field" htmlFor="label-newsletter">
+                                        <span className="settings-field-label">ニュースレター（newsletter）</span>
+                                        <input
+                                            id="label-newsletter"
+                                            className="settings-input"
+                                            type="text"
+                                            value={classificationLabelSettings.newsletterLabelName}
+                                            onChange={(event) => {
+                                                updateClassificationLabelField('newsletterLabelName', event.target.value);
+                                            }}
+                                            disabled={classificationLabelPending || !classificationLabelLoaded}
+                                        />
+                                    </label>
+                                    <label className="settings-field" htmlFor="label-archive">
+                                        <span className="settings-field-label">アーカイブ（archive）</span>
+                                        <input
+                                            id="label-archive"
+                                            className="settings-input"
+                                            type="text"
+                                            value={classificationLabelSettings.archiveLabelName}
+                                            onChange={(event) => {
+                                                updateClassificationLabelField('archiveLabelName', event.target.value);
+                                            }}
+                                            disabled={classificationLabelPending || !classificationLabelLoaded}
+                                        />
+                                    </label>
+                                    <label className="settings-field" htmlFor="label-unread-priority">
+                                        <span className="settings-field-label">未読優先（unread_priority）</span>
+                                        <input
+                                            id="label-unread-priority"
+                                            className="settings-input"
+                                            type="text"
+                                            value={classificationLabelSettings.unreadPriorityLabelName}
+                                            onChange={(event) => {
+                                                updateClassificationLabelField('unreadPriorityLabelName', event.target.value);
+                                            }}
+                                            disabled={classificationLabelPending || !classificationLabelLoaded}
+                                        />
+                                    </label>
+                                    <label className="settings-field" htmlFor="label-needs-review">
+                                        <span className="settings-field-label">要確認（needs_review）</span>
+                                        <input
+                                            id="label-needs-review"
+                                            className="settings-input"
+                                            type="text"
+                                            value={classificationLabelSettings.needsReviewLabelName}
+                                            onChange={(event) => {
+                                                updateClassificationLabelField('needsReviewLabelName', event.target.value);
+                                            }}
+                                            disabled={classificationLabelPending || !classificationLabelLoaded}
+                                        />
+                                    </label>
+                                </div>
+                                <div className="settings-action-row">
+                                    <button
+                                        className="settings-action-button"
+                                        type="button"
+                                        onClick={() => {
+                                            void handleSaveClassificationLabelSettings();
+                                        }}
+                                        disabled={classificationLabelPending || !classificationLabelLoaded}
+                                    >
+                                        {classificationLabelPending ? '保存中...' : '分類ラベル設定を保存'}
+                                    </button>
+                                </div>
+                                {classificationLabelMessage ? (
+                                    <p className="settings-inline-note">{classificationLabelMessage}</p>
+                                ) : null}
+                                {classificationLabelError ? (
+                                    <p className="settings-error-note">{classificationLabelError}</p>
+                                ) : null}
                             </div>
                         </li>
                     </ul>

--- a/internal/gmail/actions.go
+++ b/internal/gmail/actions.go
@@ -22,12 +22,6 @@ const (
 
 	systemLabelInbox  = "INBOX"
 	systemLabelUnread = "UNREAD"
-
-	mairuLabelImportant      = "Mairu/Important"
-	mairuLabelNewsletter     = "Mairu/Newsletter"
-	mairuLabelArchive        = "Mairu/Archive"
-	mairuLabelUnreadPriority = "Mairu/Unread Priority"
-	mairuLabelNeedsReview    = "Mairu/Needs Review"
 )
 
 type gmailLabel struct {
@@ -66,13 +60,14 @@ func (c *Client) ExecuteActions(
 	ctx context.Context,
 	accessToken string,
 	decisions []types.GmailActionDecision,
+	labelSettings types.ClassificationLabelSettings,
 ) (types.ExecuteGmailActionsResult, error) {
 	trimmedToken := strings.TrimSpace(accessToken)
 	if trimmedToken == "" {
 		return types.ExecuteGmailActionsResult{}, fmt.Errorf("Gmail API 呼び出しに必要な access token がありません")
 	}
 
-	plans, requiredLabels, err := buildActionPlans(decisions)
+	plans, requiredLabels, err := buildActionPlans(decisions, labelSettings)
 	if err != nil {
 		return types.ExecuteGmailActionsResult{}, err
 	}
@@ -168,10 +163,13 @@ func (c *Client) ExecuteActions(
 
 func buildActionPlans(
 	decisions []types.GmailActionDecision,
+	labelSettings types.ClassificationLabelSettings,
 ) ([]actionPlan, []string, error) {
 	if len(decisions) == 0 {
 		return nil, nil, fmt.Errorf("実行対象のメールが選択されていません")
 	}
+
+	normalizedLabelSettings := types.NormalizeClassificationLabelSettings(labelSettings)
 
 	plans := make([]actionPlan, 0, len(decisions))
 	requiredLabels := make(map[string]struct{})
@@ -203,25 +201,25 @@ func buildActionPlans(
 
 		switch decision.Category {
 		case types.ClassificationCategoryImportant:
-			plan.addLabelNames = append(plan.addLabelNames, mairuLabelImportant)
+			plan.addLabelNames = append(plan.addLabelNames, normalizedLabelSettings.ImportantLabelName)
 		case types.ClassificationCategoryNewsletter:
-			plan.addLabelNames = append(plan.addLabelNames, mairuLabelNewsletter)
+			plan.addLabelNames = append(plan.addLabelNames, normalizedLabelSettings.NewsletterLabelName)
 			plan.hasMarkRead = true
 			plan.removeLabelIDs = append(plan.removeLabelIDs, systemLabelUnread)
 		case types.ClassificationCategoryJunk:
 			plan.delete = true
 		case types.ClassificationCategoryArchive:
-			plan.addLabelNames = append(plan.addLabelNames, mairuLabelArchive)
+			plan.addLabelNames = append(plan.addLabelNames, normalizedLabelSettings.ArchiveLabelName)
 			plan.hasArchive = true
 			plan.removeLabelIDs = append(plan.removeLabelIDs, systemLabelInbox)
 		case types.ClassificationCategoryUnreadPriority:
-			plan.addLabelNames = append(plan.addLabelNames, mairuLabelUnreadPriority)
+			plan.addLabelNames = append(plan.addLabelNames, normalizedLabelSettings.UnreadPriorityLabelName)
 			plan.addSystemLabelIDs = append(plan.addSystemLabelIDs, systemLabelUnread)
 		}
 
 		if !plan.delete && (decision.ReviewLevel == types.ClassificationReviewLevelHold ||
 			decision.ReviewLevel == types.ClassificationReviewLevelReviewWithReason) {
-			plan.addLabelNames = append(plan.addLabelNames, mairuLabelNeedsReview)
+			plan.addLabelNames = append(plan.addLabelNames, normalizedLabelSettings.NeedsReviewLabelName)
 		}
 
 		plan.addLabelNames = uniqueStrings(plan.addLabelNames)

--- a/internal/gmail/actions_test.go
+++ b/internal/gmail/actions_test.go
@@ -38,8 +38,8 @@ func TestExecuteActionsCreatesLabelsAndAppliesOperations(t *testing.T) {
 					}
 					var request createLabelRequest
 					mustDecodeJSONBody(t, r, &request)
-					if request.Name != mairuLabelArchive {
-						t.Fatalf("step1 label: got %q, want %q", request.Name, mairuLabelArchive)
+					if request.Name != types.DefaultClassificationLabelArchive {
+						t.Fatalf("step1 label: got %q, want %q", request.Name, types.DefaultClassificationLabelArchive)
 					}
 					step++
 					return jsonResponse(http.StatusOK, `{"id":"LabelArchive","name":"Mairu/Archive","type":"user"}`), nil
@@ -52,8 +52,8 @@ func TestExecuteActionsCreatesLabelsAndAppliesOperations(t *testing.T) {
 					}
 					var request createLabelRequest
 					mustDecodeJSONBody(t, r, &request)
-					if request.Name != mairuLabelImportant {
-						t.Fatalf("step2 label: got %q, want %q", request.Name, mairuLabelImportant)
+					if request.Name != types.DefaultClassificationLabelImportant {
+						t.Fatalf("step2 label: got %q, want %q", request.Name, types.DefaultClassificationLabelImportant)
 					}
 					step++
 					return jsonResponse(http.StatusOK, `{"id":"LabelImportant","name":"Mairu/Important","type":"user"}`), nil
@@ -137,7 +137,7 @@ func TestExecuteActionsCreatesLabelsAndAppliesOperations(t *testing.T) {
 			Category:    types.ClassificationCategoryJunk,
 			ReviewLevel: types.ClassificationReviewLevelReview,
 		},
-	})
+	}, types.ClassificationLabelSettings{})
 	if err != nil {
 		t.Fatalf("ExecuteActions returned error: %v", err)
 	}
@@ -218,7 +218,7 @@ func TestExecuteActionsKeepsProcessingOnPartialFailure(t *testing.T) {
 			Category:    types.ClassificationCategoryJunk,
 			ReviewLevel: types.ClassificationReviewLevelReview,
 		},
-	})
+	}, types.ClassificationLabelSettings{})
 	if err != nil {
 		t.Fatalf("ExecuteActions returned error: %v", err)
 	}
@@ -264,7 +264,7 @@ func TestBuildActionPlansAddsNeedsReviewLabel(t *testing.T) {
 			Category:    types.ClassificationCategoryUnreadPriority,
 			ReviewLevel: types.ClassificationReviewLevelReviewWithReason,
 		},
-	})
+	}, types.ClassificationLabelSettings{})
 	if err != nil {
 		t.Fatalf("buildActionPlans returned error: %v", err)
 	}
@@ -282,6 +282,42 @@ func TestBuildActionPlansAddsNeedsReviewLabel(t *testing.T) {
 	}
 }
 
+func TestBuildActionPlansUsesCustomLabelNames(t *testing.T) {
+	t.Parallel()
+
+	plans, requiredLabels, err := buildActionPlans([]types.GmailActionDecision{
+		{
+			MessageID:   "msg-1",
+			Category:    types.ClassificationCategoryImportant,
+			ReviewLevel: types.ClassificationReviewLevelHold,
+		},
+		{
+			MessageID:   "msg-2",
+			Category:    types.ClassificationCategoryUnreadPriority,
+			ReviewLevel: types.ClassificationReviewLevelAutoApply,
+		},
+	}, types.ClassificationLabelSettings{
+		ImportantLabelName:      "Team/Important",
+		UnreadPriorityLabelName: "Team/Unread",
+		NeedsReviewLabelName:    "Team/Review",
+	})
+	if err != nil {
+		t.Fatalf("buildActionPlans returned error: %v", err)
+	}
+	if len(plans) != 2 {
+		t.Fatalf("plans length = %d, want 2", len(plans))
+	}
+	if got := strings.Join(plans[0].addLabelNames, ","); got != "Team/Important,Team/Review" {
+		t.Fatalf("plans[0].addLabelNames = %v", plans[0].addLabelNames)
+	}
+	if got := strings.Join(plans[1].addLabelNames, ","); got != "Team/Unread" {
+		t.Fatalf("plans[1].addLabelNames = %v", plans[1].addLabelNames)
+	}
+	if got := strings.Join(requiredLabels, ","); got != "Team/Important,Team/Review,Team/Unread" {
+		t.Fatalf("requiredLabels = %v", requiredLabels)
+	}
+}
+
 func TestBuildActionPlansSkipsNeedsReviewLabelForDelete(t *testing.T) {
 	t.Parallel()
 
@@ -291,7 +327,7 @@ func TestBuildActionPlansSkipsNeedsReviewLabelForDelete(t *testing.T) {
 			Category:    types.ClassificationCategoryJunk,
 			ReviewLevel: types.ClassificationReviewLevelHold,
 		},
-	})
+	}, types.ClassificationLabelSettings{})
 	if err != nil {
 		t.Fatalf("buildActionPlans returned error: %v", err)
 	}
@@ -361,7 +397,7 @@ func TestExecuteActionsLabelCreateRaceFallsBackToRelist(t *testing.T) {
 			Category:    types.ClassificationCategoryImportant,
 			ReviewLevel: types.ClassificationReviewLevelReview,
 		},
-	})
+	}, types.ClassificationLabelSettings{})
 	if err != nil {
 		t.Fatalf("ExecuteActions returned error: %v", err)
 	}

--- a/internal/types/dto.go
+++ b/internal/types/dto.go
@@ -34,6 +34,14 @@ const (
 	ClassificationReasonHintMinimum = 0.50
 )
 
+const (
+	DefaultClassificationLabelImportant      = "Mairu/Important"
+	DefaultClassificationLabelNewsletter     = "Mairu/Newsletter"
+	DefaultClassificationLabelArchive        = "Mairu/Archive"
+	DefaultClassificationLabelUnreadPriority = "Mairu/Unread Priority"
+	DefaultClassificationLabelNeedsReview    = "Mairu/Needs Review"
+)
+
 // IsValid は既知の分類カテゴリかを判定する。
 func (c ClassificationCategory) IsValid() bool {
 	switch c {
@@ -101,6 +109,58 @@ func ReviewLevelForConfidence(confidence float64) ClassificationReviewLevel {
 	default:
 		return ClassificationReviewLevelHold
 	}
+}
+
+// ClassificationLabelSettings は自動分別時に使う Gmail ラベル名の設定を表す。
+type ClassificationLabelSettings struct {
+	ImportantLabelName      string
+	NewsletterLabelName     string
+	ArchiveLabelName        string
+	UnreadPriorityLabelName string
+	NeedsReviewLabelName    string
+}
+
+// UpdateClassificationLabelSettingsRequest は分類ラベル設定の更新入力を表す。
+type UpdateClassificationLabelSettingsRequest struct {
+	ImportantLabelName      string
+	NewsletterLabelName     string
+	ArchiveLabelName        string
+	UnreadPriorityLabelName string
+	NeedsReviewLabelName    string
+}
+
+// DefaultClassificationLabelSettings は分類ラベル設定の既定値を返す。
+func DefaultClassificationLabelSettings() ClassificationLabelSettings {
+	return ClassificationLabelSettings{
+		ImportantLabelName:      DefaultClassificationLabelImportant,
+		NewsletterLabelName:     DefaultClassificationLabelNewsletter,
+		ArchiveLabelName:        DefaultClassificationLabelArchive,
+		UnreadPriorityLabelName: DefaultClassificationLabelUnreadPriority,
+		NeedsReviewLabelName:    DefaultClassificationLabelNeedsReview,
+	}
+}
+
+// NormalizeClassificationLabelSettings は空欄や空白のみを既定値へ補完する。
+func NormalizeClassificationLabelSettings(
+	settings ClassificationLabelSettings,
+) ClassificationLabelSettings {
+	defaults := DefaultClassificationLabelSettings()
+
+	return ClassificationLabelSettings{
+		ImportantLabelName:      normalizeClassificationLabel(settings.ImportantLabelName, defaults.ImportantLabelName),
+		NewsletterLabelName:     normalizeClassificationLabel(settings.NewsletterLabelName, defaults.NewsletterLabelName),
+		ArchiveLabelName:        normalizeClassificationLabel(settings.ArchiveLabelName, defaults.ArchiveLabelName),
+		UnreadPriorityLabelName: normalizeClassificationLabel(settings.UnreadPriorityLabelName, defaults.UnreadPriorityLabelName),
+		NeedsReviewLabelName:    normalizeClassificationLabel(settings.NeedsReviewLabelName, defaults.NeedsReviewLabelName),
+	}
+}
+
+func normalizeClassificationLabel(value string, fallback string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return fallback
+	}
+	return trimmed
 }
 
 // ClassificationRequest は Claude 分類 API 呼び出し入力を表す。

--- a/internal/types/dto_test.go
+++ b/internal/types/dto_test.go
@@ -157,6 +157,55 @@ func TestBlocklistKindIsValid(t *testing.T) {
 	}
 }
 
+func TestDefaultClassificationLabelSettings(t *testing.T) {
+	t.Parallel()
+
+	got := DefaultClassificationLabelSettings()
+	if got.ImportantLabelName != DefaultClassificationLabelImportant {
+		t.Fatalf("ImportantLabelName = %q, want %q", got.ImportantLabelName, DefaultClassificationLabelImportant)
+	}
+	if got.NewsletterLabelName != DefaultClassificationLabelNewsletter {
+		t.Fatalf("NewsletterLabelName = %q, want %q", got.NewsletterLabelName, DefaultClassificationLabelNewsletter)
+	}
+	if got.ArchiveLabelName != DefaultClassificationLabelArchive {
+		t.Fatalf("ArchiveLabelName = %q, want %q", got.ArchiveLabelName, DefaultClassificationLabelArchive)
+	}
+	if got.UnreadPriorityLabelName != DefaultClassificationLabelUnreadPriority {
+		t.Fatalf("UnreadPriorityLabelName = %q, want %q", got.UnreadPriorityLabelName, DefaultClassificationLabelUnreadPriority)
+	}
+	if got.NeedsReviewLabelName != DefaultClassificationLabelNeedsReview {
+		t.Fatalf("NeedsReviewLabelName = %q, want %q", got.NeedsReviewLabelName, DefaultClassificationLabelNeedsReview)
+	}
+}
+
+func TestNormalizeClassificationLabelSettings(t *testing.T) {
+	t.Parallel()
+
+	got := NormalizeClassificationLabelSettings(ClassificationLabelSettings{
+		ImportantLabelName:      "  Custom/Important ",
+		NewsletterLabelName:     "",
+		ArchiveLabelName:        " ",
+		UnreadPriorityLabelName: "\tCustom/Unread\t",
+		NeedsReviewLabelName:    "Custom/Needs Review",
+	})
+
+	if got.ImportantLabelName != "Custom/Important" {
+		t.Fatalf("ImportantLabelName = %q, want %q", got.ImportantLabelName, "Custom/Important")
+	}
+	if got.NewsletterLabelName != DefaultClassificationLabelNewsletter {
+		t.Fatalf("NewsletterLabelName = %q, want %q", got.NewsletterLabelName, DefaultClassificationLabelNewsletter)
+	}
+	if got.ArchiveLabelName != DefaultClassificationLabelArchive {
+		t.Fatalf("ArchiveLabelName = %q, want %q", got.ArchiveLabelName, DefaultClassificationLabelArchive)
+	}
+	if got.UnreadPriorityLabelName != "Custom/Unread" {
+		t.Fatalf("UnreadPriorityLabelName = %q, want %q", got.UnreadPriorityLabelName, "Custom/Unread")
+	}
+	if got.NeedsReviewLabelName != "Custom/Needs Review" {
+		t.Fatalf("NeedsReviewLabelName = %q, want %q", got.NeedsReviewLabelName, "Custom/Needs Review")
+	}
+}
+
 func TestGWSCLIErrorKindValues(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
# Pull Request

## 概要

自動分別で Gmail に付与するラベル名を固定値から分離し、Settings 画面でカテゴリ別に任意設定できるようにしました。手動実行・safe-run 自動実行の両方で同じ設定を使用します。

Closes #50

## 種別

- [x] ✨ 機能追加
- [ ] 🐛 バグ修正
- [ ] ♻️ リファクタリング
- [x] 📝 ドキュメント
- [x] 🧪 テスト追加・修正
- [ ] 🔧 設定・CI/CD

## 対応フェーズ / Issue

- Phase 4
- MAIRU-025 / #50

## 変更内容

- `internal/types` に分類ラベル設定 DTO・既定値・正規化処理を追加
- `app.go` に分類ラベル設定の取得/更新 API を追加し、DB `settings` へ保存
- `internal/gmail/actions` をラベル設定注入型に変更し、カテゴリごとの適用ラベル名を動的化
- `frontend/src/lib/runtime.ts` に新 API バインディングを追加
- `frontend/src/pages/Settings/SettingsPage.tsx` に「自動分別ラベル名」編集 UI を追加
- `docs/ISSUES.md` に `MAIRU-025 / #50` を追加
- Go テストを追加し、カスタムラベルが実際に Gmail 反映で使われることを検証

## Issue 対応メモ

- [x] ブランチ名にローカル issue ID を含めた
- [x] コミットメッセージにローカル issue ID を含めた
- [x] `docs/ISSUES.md` の対象 issue と整合している
- [ ] `.github/ISSUE_CLOSE_COMMENT_TEMPLATE.md` を使って完了コメントを残す
- [ ] マージ後に対象 issue を `status: done` にしてクローズする

## 動作確認

- [ ] `wails dev` で起動確認
- [x] `go test ./internal/...` パス
- [ ] `cd frontend && npx vitest --run` パス
- [ ] 画面上で手動確認済み

実行ログ:
- `go test ./...` ✅
- `pnpm test -- --runInBand` は `pnpm` 未導入で実行不可
- `cd frontend && npm test -- --runInBand`（`tsc --noEmit`）✅

## スクリーンショット

- UI 変更あり（今回は未添付）

## AI レビューへの注記

- `ExecuteGmailActions` は既存の手動実行経路と scheduler safe-run 経路で共通利用しているため、今回のラベル設定適用は両方に自動反映されます。
- 空入力はバックエンドで既定値へ正規化して保存/利用しています。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ラベル名のカスタマイズ機能を追加。設定ページで重要、ニュースレター、アーカイブ、優先度、レビュー必要なラベルの名前を設定可能に。
  * カスタマイズされたラベル名はGmailの自動分類アクションで使用される。設定を保存するとデータベースに永続化され、未設定時はデフォルト値で対応。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->